### PR TITLE
Stringify arguments to score functions

### DIFF
--- a/tools/buildchallenge.js
+++ b/tools/buildchallenge.js
@@ -45,7 +45,8 @@ function parseScore(xml) {
         return 'if ('+conditions+') {return '+line.returnValue+'}';
     }).join('\n');
     var args = unique(deps).join(',');
-    return 'function('+args+') {'+lines+'}';
+    var strArgs = unique(deps).map(arg => arg + ' = String(' + arg + ')').join(';')
+    return 'function('+args+') {'+strArgs+';'+lines+'}';
 }
 
 function parseObjective(xml) {


### PR DESCRIPTION
This pull request causes the mission score functions in the challenge.js file to do a String conversion for each of their arguments.  

Issue:
objective-number produces a number as the score function argument
score function compares (===) against string value

Sample output in challenge.js:
            "score": [function(M05_lg, M05_sm, bonus) {
                M05_lg = String(M05_lg);
                M05_sm = String(M05_sm);
                bonus = String(bonus);
                if (M05_lg === '0' && M05_sm === '0' && bonus === 'no') {
                    return 0
                }
etc...
