### PR TITLE
Update 2 for 2019_US.xml

### DIFF
--- a/challenges/js/2019_US.js
+++ b/challenges/js/2019_US.js
@@ -9,6 +9,7 @@
                 "type": "yesno"
             }],
             "score": [function(bonus) {
+                bonus = String(bonus);
                 if (bonus === 'no') {
                     return 0
                 }
@@ -45,6 +46,9 @@
                 }
             ],
             "score": [function(M01_1, M01_2, bonus) {
+                M01_1 = String(M01_1);
+                M01_2 = String(M01_2);
+                bonus = String(bonus);
                 if (M01_1 === 'no' && M01_2 === '0' && bonus === 'no') {
                     return 0
                 }
@@ -102,62 +106,31 @@
                     "type": "yesno"
                 }
             ],
-            "score": [function(M02_1, M02_2, M02_3, bonus, M05_lg, M05_sm, M12_2, M12_3) {
-                if (((M02_2 === 'yes') ? 1 : 0) + ({
-                        "0": 0,
-                        "1": 1,
-                        "2": 2,
-                        "3": 3,
-                        "4": 4,
-                        "5": 5,
-                        "6": 6,
-                        "7": 7,
-                        "8": 8
-                    } [M05_lg]) + ({
-                        "0": 0,
-                        "1": 1,
-                        "2": 2,
-                        "3": 3,
-                        "4": 4,
-                        "5": 5,
-                        "6": 6,
-                        "7": 7,
-                        "8": 8
-                    } [M05_sm]) + ({
-                        "0": 0,
-                        "1": 10,
-                        "2": 20
-                    } [M12_2]) + ({
-                        "0": 0,
-                        "1": 1,
-                        "2": 2,
-                        "3": 3,
-                        "4": 4,
-                        "5": 5,
-                        "6": 6,
-                        "7": 7,
-                        "8": 8,
-                        "9": 9
-                    } [M12_3]) > 20) {
-                    return new Error('Too many building units in use')
+            "score": [function(M02_1, M02_2, M02_3, bonus, M05_lg, M05_sm, M12_4) {
+                M02_1 = String(M02_1);
+                M02_2 = String(M02_2);
+                M02_3 = String(M02_3);
+                bonus = String(bonus);
+                if (((M02_1 === 'yes') ? 1 : 0) + ((M02_2 === 'yes') ? 1 : 0) + (M05_lg * 1) + (M05_sm * 1) + (M12_4 * 0.5) > 17) {
+                    return new Error('Too many Building Units in use')
                 }
                 if (M02_1 === 'no' && M02_2 === 'no' && M02_3 === 'no' && bonus === 'no') {
                     return 0
                 }
                 if (M02_1 === 'no' && M02_2 === 'no' && M02_3 === 'yes' && bonus === 'no') {
-                    return 0
+                    return new Error("Conflict in position of Blue Units")
                 }
                 if (M02_1 === 'no' && M02_2 === 'yes' && M02_3 === 'no' && bonus === 'no') {
-                    return 0
+                    return new Error("Conflict in position of Blue Units")
                 }
                 if (M02_1 === 'no' && M02_2 === 'yes' && M02_3 === 'yes' && bonus === 'no') {
-                    return 0
+                    return new Error("Conflict in position of Blue Units")
                 }
                 if (M02_1 === 'yes' && M02_2 === 'no' && M02_3 === 'no' && bonus === 'no') {
                     return 20
                 }
                 if (M02_1 === 'yes' && M02_2 === 'no' && M02_3 === 'yes' && bonus === 'no') {
-                    return 20
+                    return new Error("Conflict in position of Blue Units")
                 }
                 if (M02_1 === 'yes' && M02_2 === 'yes' && M02_3 === 'no' && bonus === 'no') {
                     return 35
@@ -169,19 +142,19 @@
                     return 0
                 }
                 if (M02_1 === 'no' && M02_2 === 'no' && M02_3 === 'yes' && bonus === 'yes') {
-                    return 0
+                    return new Error("Conflict in position of Blue Units")
                 }
                 if (M02_1 === 'no' && M02_2 === 'yes' && M02_3 === 'no' && bonus === 'yes') {
-                    return 0
+                    return new Error("Conflict in position of Blue Units")
                 }
                 if (M02_1 === 'no' && M02_2 === 'yes' && M02_3 === 'yes' && bonus === 'yes') {
-                    return 0
+                    return new Error("Conflict in position of Blue Units")
                 }
                 if (M02_1 === 'yes' && M02_2 === 'no' && M02_3 === 'no' && bonus === 'yes') {
                     return 30
                 }
                 if (M02_1 === 'yes' && M02_2 === 'no' && M02_3 === 'yes' && bonus === 'yes') {
-                    return 30
+                    return new Error("Conflict in position of Blue Units")
                 }
                 if (M02_1 === 'yes' && M02_2 === 'yes' && M02_3 === 'no' && bonus === 'yes') {
                     return 45
@@ -200,6 +173,8 @@
                 "type": "yesno"
             }],
             "score": [function(M03_1, bonus) {
+                M03_1 = String(M03_1);
+                bonus = String(bonus);
                 if (M03_1 === 'no' && bonus === 'no') {
                     return 0
                 }
@@ -223,6 +198,8 @@
                 "type": "yesno"
             }],
             "score": [function(M04_1, bonus) {
+                M04_1 = String(M04_1);
+                bonus = String(bonus);
                 if (M04_1 === 'no' && bonus === 'no') {
                     return 0
                 }
@@ -243,126 +220,24 @@
             "objectives": [{
                     "id": "M05_lg",
                     "title": "Number of Units Independent and Supported by the Tree's Large Branches:",
-                    "options": [{
-                            "value": "0",
-                            "title": "0"
-                        },
-                        {
-                            "value": "1",
-                            "title": "1"
-                        },
-                        {
-                            "value": "2",
-                            "title": "2"
-                        },
-                        {
-                            "value": "3",
-                            "title": "3"
-                        },
-                        {
-                            "value": "4",
-                            "title": "4"
-                        },
-                        {
-                            "value": "5",
-                            "title": "5"
-                        },
-                        {
-                            "value": "6",
-                            "title": "6"
-                        },
-                        {
-                            "value": "7",
-                            "title": "7"
-                        },
-                        {
-                            "value": "8",
-                            "title": "8"
-                        }
-                    ],
-                    "type": "enum"
+                    "type": "number",
+                    "min": "0",
+                    "max": "10"
                 },
                 {
                     "id": "M05_sm",
                     "title": "Number of Units Independent and Supported by the Tree's Small Branches:",
-                    "options": [{
-                            "value": "0",
-                            "title": "0"
-                        },
-                        {
-                            "value": "1",
-                            "title": "1"
-                        },
-                        {
-                            "value": "2",
-                            "title": "2"
-                        },
-                        {
-                            "value": "3",
-                            "title": "3"
-                        },
-                        {
-                            "value": "4",
-                            "title": "4"
-                        },
-                        {
-                            "value": "5",
-                            "title": "5"
-                        },
-                        {
-                            "value": "6",
-                            "title": "6"
-                        },
-                        {
-                            "value": "7",
-                            "title": "7"
-                        },
-                        {
-                            "value": "8",
-                            "title": "8"
-                        }
-                    ],
-                    "type": "enum"
+                    "type": "number",
+                    "min": "0",
+                    "max": "10"
                 }
             ],
-            "score": [function(M05_lg, M05_sm, bonus, M02_2, M12_2, M12_3) {
-                if (((M02_2 === 'yes') ? 1 : 0) + ({
-                        "0": 0,
-                        "1": 1,
-                        "2": 2,
-                        "3": 3,
-                        "4": 4,
-                        "5": 5,
-                        "6": 6,
-                        "7": 7,
-                        "8": 8
-                    } [M05_lg]) + ({
-                        "0": 0,
-                        "1": 1,
-                        "2": 2,
-                        "3": 3,
-                        "4": 4,
-                        "5": 5,
-                        "6": 6,
-                        "7": 7,
-                        "8": 8
-                    } [M05_sm]) + ({
-                        "0": 0,
-                        "1": 10,
-                        "2": 20
-                    } [M12_2]) + ({
-                        "0": 0,
-                        "1": 1,
-                        "2": 2,
-                        "3": 3,
-                        "4": 4,
-                        "5": 5,
-                        "6": 6,
-                        "7": 7,
-                        "8": 8,
-                        "9": 9
-                    } [M12_3]) > 20) {
-                    return new Error('Too many building units in use')
+            "score": [function(M05_lg, M05_sm, bonus, M02_1, M02_2, M12_4) {
+                M05_lg = String(M05_lg);
+                M05_sm = String(M05_sm);
+                bonus = String(bonus);
+                if (((M02_1 === 'yes') ? 1 : 0) + ((M02_2 === 'yes') ? 1 : 0) + (M05_lg * 1) + (M05_sm * 1) + (M12_4 * 0.5) > 17) {
+                    return new Error('Too many Building Units in use')
                 }
                 if (M05_lg === '0' && M05_sm === '0' && bonus === 'no') {
                     return 0
@@ -626,7 +501,7 @@
                     return 205
                 }
                 if (M05_lg === '7' && M05_sm === '10' && bonus === 'no') {
-                    return new Error("Too many levels")
+                    return new Error("Too many Building Units in use")
                 }
                 if (M05_lg === '8' && M05_sm === '0' && bonus === 'no') {
                     return 80
@@ -656,10 +531,10 @@
                     return 200
                 }
                 if (M05_lg === '8' && M05_sm === '9' && bonus === 'no') {
-                    return new Error("Too many levels")
+                    return new Error("Too many Building Units in use")
                 }
                 if (M05_lg === '8' && M05_sm === '10' && bonus === 'no') {
-                    return new Error("Too many levels")
+                    return new Error("Too many Building Units in use")
                 }
                 if (M05_lg === '9' && M05_sm === '0' && bonus === 'no') {
                     return 90
@@ -686,13 +561,13 @@
                     return 195
                 }
                 if (M05_lg === '9' && M05_sm === '8' && bonus === 'no') {
-                    return new Error("Too many levels")
+                    return new Error("Too many Building Units in use")
                 }
                 if (M05_lg === '9' && M05_sm === '9' && bonus === 'no') {
-                    return new Error("Too many levels")
+                    return new Error("Too many Building Units in use")
                 }
                 if (M05_lg === '9' && M05_sm === '10' && bonus === 'no') {
-                    return new Error("Too many levels")
+                    return new Error("Too many Building Units in use")
                 }
                 if (M05_lg === '10' && M05_sm === '0' && bonus === 'no') {
                     return 100
@@ -716,16 +591,16 @@
                     return 190
                 }
                 if (M05_lg === '10' && M05_sm === '7' && bonus === 'no') {
-                    return new Error("Too many levels")
+                    return new Error("Too many Building Units in use")
                 }
                 if (M05_lg === '10' && M05_sm === '8' && bonus === 'no') {
-                    return new Error("Too many levels")
+                    return new Error("Too many Building Units in use")
                 }
                 if (M05_lg === '10' && M05_sm === '9' && bonus === 'no') {
-                    return new Error("Too many levels")
+                    return new Error("Too many Building Units in use")
                 }
                 if (M05_lg === '10' && M05_sm === '10' && bonus === 'no') {
-                    return new Error("Too many levels")
+                    return new Error("Too many Building Units in use")
                 }
                 if (M05_lg === '0' && M05_sm === '0' && bonus === 'yes') {
                     return 0
@@ -989,7 +864,7 @@
                     return 210
                 }
                 if (M05_lg === '7' && M05_sm === '10' && bonus === 'yes') {
-                    return new Error("Too many levels")
+                    return new Error("Too many Building Units in use")
                 }
                 if (M05_lg === '8' && M05_sm === '0' && bonus === 'yes') {
                     return 85
@@ -1019,10 +894,10 @@
                     return 205
                 }
                 if (M05_lg === '8' && M05_sm === '9' && bonus === 'yes') {
-                    return new Error("Too many levels")
+                    return new Error("Too many Building Units in use")
                 }
                 if (M05_lg === '8' && M05_sm === '10' && bonus === 'yes') {
-                    return new Error("Too many levels")
+                    return new Error("Too many Building Units in use")
                 }
                 if (M05_lg === '9' && M05_sm === '0' && bonus === 'yes') {
                     return 95
@@ -1049,13 +924,13 @@
                     return 200
                 }
                 if (M05_lg === '9' && M05_sm === '8' && bonus === 'yes') {
-                    return new Error("Too many levels")
+                    return new Error("Too many Building Units in use")
                 }
                 if (M05_lg === '9' && M05_sm === '9' && bonus === 'yes') {
-                    return new Error("Too many levels")
+                    return new Error("Too many Building Units in use")
                 }
                 if (M05_lg === '9' && M05_sm === '10' && bonus === 'yes') {
-                    return new Error("Too many levels")
+                    return new Error("Too many Building Units in use")
                 }
                 if (M05_lg === '10' && M05_sm === '0' && bonus === 'yes') {
                     return 105
@@ -1079,16 +954,16 @@
                     return 195
                 }
                 if (M05_lg === '10' && M05_sm === '7' && bonus === 'yes') {
-                    return new Error("Too many levels")
+                    return new Error("Too many Building Units in use")
                 }
                 if (M05_lg === '10' && M05_sm === '8' && bonus === 'yes') {
-                    return new Error("Too many levels")
+                    return new Error("Too many Building Units in use")
                 }
                 if (M05_lg === '10' && M05_sm === '9' && bonus === 'yes') {
-                    return new Error("Too many levels")
+                    return new Error("Too many Building Units in use")
                 }
                 if (M05_lg === '10' && M05_sm === '10' && bonus === 'yes') {
-                    return new Error("Too many levels")
+                    return new Error("Too many Building Units in use")
                 }
             }]
         },
@@ -1101,6 +976,8 @@
                 "type": "yesno"
             }],
             "score": [function(M06_1, bonus) {
+                M06_1 = String(M06_1);
+                bonus = String(bonus);
                 if (M06_1 === 'no' && bonus === 'no') {
                     return 0
                 }
@@ -1124,6 +1001,8 @@
                 "type": "yesno"
             }],
             "score": [function(M07_1, bonus) {
+                M07_1 = String(M07_1);
+                bonus = String(bonus);
                 if (M07_1 === 'no' && bonus === 'no') {
                     return 0
                 }
@@ -1160,6 +1039,8 @@
                 "type": "enum"
             }],
             "score": [function(M08_1, bonus) {
+                M08_1 = String(M08_1);
+                bonus = String(bonus);
                 if (M08_1 === 'neither' && bonus === 'no') {
                     return 0
                 }
@@ -1224,6 +1105,9 @@
                 }
             ],
             "score": [function(M09_1, M09_2, bonus) {
+                M09_1 = String(M09_1);
+                M09_2 = String(M09_2);
+                bonus = String(bonus);
                 if (M09_1 === 'no' && M09_2 === '0' && bonus === 'no') {
                     return 0
                 }
@@ -1319,6 +1203,8 @@
                 "type": "yesno"
             }],
             "score": [function(M10, bonus) {
+                M10 = String(M10);
+                bonus = String(bonus);
                 if (M10 === 'no' && bonus === 'no') {
                     return 0
                 }
@@ -1361,6 +1247,9 @@
                 }
             ],
             "score": [function(M11_1, M11_2, bonus) {
+                M11_1 = String(M11_1);
+                M11_2 = String(M11_2);
+                bonus = String(bonus);
                 if (M11_1 === 'no' && M11_2 === 'no' && bonus === 'no') {
                     return 0
                 }
@@ -1425,828 +1314,739 @@
                     "type": "enum"
                 },
                 {
-                    "id": "M12_2",
-                    "title": "Sum of heights of all Independent Stacks at least partly in any Circle (tens digit):",
-                    "options": [{
-                            "value": "0",
-                            "title": "0"
-                        },
-                        {
-                            "value": "1",
-                            "title": "1"
-                        },
-                        {
-                            "value": "2",
-                            "title": "2"
-                        }
-                    ],
-                    "type": "enum"
-                },
-                {
-                    "id": "M12_3",
-                    "title": "Sum of heights of all Independent Stacks at least partly in any Circle (ones digit):",
-                    "options": [{
-                            "value": "0",
-                            "title": "0"
-                        },
-                        {
-                            "value": "1",
-                            "title": "1"
-                        },
-                        {
-                            "value": "2",
-                            "title": "2"
-                        },
-                        {
-                            "value": "3",
-                            "title": "3"
-                        },
-                        {
-                            "value": "4",
-                            "title": "4"
-                        },
-                        {
-                            "value": "5",
-                            "title": "5"
-                        },
-                        {
-                            "value": "6",
-                            "title": "6"
-                        },
-                        {
-                            "value": "7",
-                            "title": "7"
-                        },
-                        {
-                            "value": "8",
-                            "title": "8"
-                        },
-                        {
-                            "value": "9",
-                            "title": "9"
-                        }
-                    ],
-                    "type": "enum"
+                    "id": "M12_4",
+                    "title": "Sum of heights of all Independent Stacks at least partly in any Circle:",
+                    "type": "number",
+                    "min": "0",
+                    "max": "29"
                 }
             ],
-            "score": [function(M12_1, M12_2, M12_3, bonus, M02_2, M05_lg, M05_sm) {
-                if (((M02_2 === 'yes') ? 1 : 0) + ({
-                        "0": 0,
-                        "1": 1,
-                        "2": 2,
-                        "3": 3,
-                        "4": 4,
-                        "5": 5,
-                        "6": 6,
-                        "7": 7,
-                        "8": 8
-                    } [M05_lg]) + ({
-                        "0": 0,
-                        "1": 1,
-                        "2": 2,
-                        "3": 3,
-                        "4": 4,
-                        "5": 5,
-                        "6": 6,
-                        "7": 7,
-                        "8": 8
-                    } [M05_sm]) + ({
-                        "0": 0,
-                        "1": 10,
-                        "2": 20
-                    } [M12_2]) + ({
-                        "0": 0,
-                        "1": 1,
-                        "2": 2,
-                        "3": 3,
-                        "4": 4,
-                        "5": 5,
-                        "6": 6,
-                        "7": 7,
-                        "8": 8,
-                        "9": 9
-                    } [M12_3]) > 20) {
-                    return new Error('Too many building units in use')
+            "score": [function(M12_1, M12_4, bonus, M02_1, M02_2, M05_lg, M05_sm) {
+                M12_1 = String(M12_1);
+                M12_4 = String(M12_4);
+                bonus = String(bonus);
+                if (((M02_1 === 'yes') ? 1 : 0) + ((M02_2 === 'yes') ? 1 : 0) + (M05_lg * 1) + (M05_sm * 1) + (M12_4 * 0.5) > 17) {
+                    return new Error('Too many Building Units in use')
                 }
-                if (M12_1 === '0' && M12_2 === '0' && M12_3 === '0' && bonus === 'no') {
+                if (M12_1 === '0' && M12_4 === '0' && bonus === 'no') {
                     return 0
                 }
-                if (M12_1 === '0' && M12_2 === '0' && M12_3 === '1' && bonus === 'no') {
+                if (M12_1 === '0' && M12_4 === '1' && bonus === 'no') {
                     return 5
                 }
-                if (M12_1 === '0' && M12_2 === '0' && M12_3 === '2' && bonus === 'no') {
+                if (M12_1 === '0' && M12_4 === '2' && bonus === 'no') {
                     return 10
                 }
-                if (M12_1 === '0' && M12_2 === '0' && M12_3 === '3' && bonus === 'no') {
+                if (M12_1 === '0' && M12_4 === '3' && bonus === 'no') {
                     return 15
                 }
-                if (M12_1 === '0' && M12_2 === '0' && M12_3 === '4' && bonus === 'no') {
+                if (M12_1 === '0' && M12_4 === '4' && bonus === 'no') {
                     return 20
                 }
-                if (M12_1 === '0' && M12_2 === '0' && M12_3 === '5' && bonus === 'no') {
+                if (M12_1 === '0' && M12_4 === '5' && bonus === 'no') {
                     return 25
                 }
-                if (M12_1 === '0' && M12_2 === '0' && M12_3 === '6' && bonus === 'no') {
+                if (M12_1 === '0' && M12_4 === '6' && bonus === 'no') {
                     return 30
                 }
-                if (M12_1 === '0' && M12_2 === '0' && M12_3 === '7' && bonus === 'no') {
+                if (M12_1 === '0' && M12_4 === '7' && bonus === 'no') {
                     return 35
                 }
-                if (M12_1 === '0' && M12_2 === '0' && M12_3 === '8' && bonus === 'no') {
+                if (M12_1 === '0' && M12_4 === '8' && bonus === 'no') {
                     return 40
                 }
-                if (M12_1 === '0' && M12_2 === '0' && M12_3 === '9' && bonus === 'no') {
+                if (M12_1 === '0' && M12_4 === '9' && bonus === 'no') {
                     return 45
                 }
-                if (M12_1 === '0' && M12_2 === '1' && M12_3 === '0' && bonus === 'no') {
+                if (M12_1 === '0' && M12_4 === '10' && bonus === 'no') {
                     return 50
                 }
-                if (M12_1 === '0' && M12_2 === '1' && M12_3 === '1' && bonus === 'no') {
+                if (M12_1 === '0' && M12_4 === '11' && bonus === 'no') {
                     return 55
                 }
-                if (M12_1 === '0' && M12_2 === '1' && M12_3 === '2' && bonus === 'no') {
+                if (M12_1 === '0' && M12_4 === '12' && bonus === 'no') {
                     return 60
                 }
-                if (M12_1 === '0' && M12_2 === '1' && M12_3 === '3' && bonus === 'no') {
+                if (M12_1 === '0' && M12_4 === '13' && bonus === 'no') {
                     return 65
                 }
-                if (M12_1 === '0' && M12_2 === '1' && M12_3 === '4' && bonus === 'no') {
+                if (M12_1 === '0' && M12_4 === '14' && bonus === 'no') {
                     return 70
                 }
-                if (M12_1 === '0' && M12_2 === '1' && M12_3 === '5' && bonus === 'no') {
+                if (M12_1 === '0' && M12_4 === '15' && bonus === 'no') {
                     return 75
                 }
-                if (M12_1 === '0' && M12_2 === '1' && M12_3 === '6' && bonus === 'no') {
+                if (M12_1 === '0' && M12_4 === '16' && bonus === 'no') {
                     return 80
                 }
-                if (M12_1 === '0' && M12_2 === '1' && M12_3 === '7' && bonus === 'no') {
+                if (M12_1 === '0' && M12_4 === '17' && bonus === 'no') {
                     return 85
                 }
-                if (M12_1 === '0' && M12_2 === '1' && M12_3 === '8' && bonus === 'no') {
+                if (M12_1 === '0' && M12_4 === '18' && bonus === 'no') {
                     return 90
                 }
-                if (M12_1 === '0' && M12_2 === '1' && M12_3 === '9' && bonus === 'no') {
+                if (M12_1 === '0' && M12_4 === '19' && bonus === 'no') {
                     return 95
                 }
-                if (M12_1 === '0' && M12_2 === '2' && M12_3 === '0' && bonus === 'no') {
+                if (M12_1 === '0' && M12_4 === '20' && bonus === 'no') {
                     return 100
                 }
-                if (M12_1 === '0' && M12_2 === '2' && M12_3 === '1' && bonus === 'no') {
+                if (M12_1 === '0' && M12_4 === '21' && bonus === 'no') {
                     return 105
                 }
-                if (M12_1 === '0' && M12_2 === '2' && M12_3 === '2' && bonus === 'no') {
+                if (M12_1 === '0' && M12_4 === '22' && bonus === 'no') {
                     return 110
                 }
-                if (M12_1 === '0' && M12_2 === '2' && M12_3 === '3' && bonus === 'no') {
+                if (M12_1 === '0' && M12_4 === '23' && bonus === 'no') {
                     return 115
                 }
-                if (M12_1 === '0' && M12_2 === '2' && M12_3 === '4' && bonus === 'no') {
+                if (M12_1 === '0' && M12_4 === '24' && bonus === 'no') {
                     return 120
                 }
-                if (M12_1 === '0' && M12_2 === '2' && M12_3 === '5' && bonus === 'no') {
+                if (M12_1 === '0' && M12_4 === '25' && bonus === 'no') {
                     return 125
                 }
-                if (M12_1 === '0' && M12_2 === '2' && M12_3 === '6' && bonus === 'no') {
+                if (M12_1 === '0' && M12_4 === '26' && bonus === 'no') {
                     return 130
                 }
-                if (M12_1 === '0' && M12_2 === '2' && M12_3 === '7' && bonus === 'no') {
+                if (M12_1 === '0' && M12_4 === '27' && bonus === 'no') {
                     return 135
                 }
-                if (M12_1 === '0' && M12_2 === '2' && M12_3 === '8' && bonus === 'no') {
+                if (M12_1 === '0' && M12_4 === '28' && bonus === 'no') {
                     return 140
                 }
-                if (M12_1 === '0' && M12_2 === '2' && M12_3 === '9' && bonus === 'no') {
-                    return new Error("Too many levels")
+                if (M12_1 === '0' && M12_4 === '29' && bonus === 'no') {
+                    return 145
                 }
-                if (M12_1 === '1' && M12_2 === '0' && M12_3 === '0' && bonus === 'no') {
-                    return 10
+                if (M12_1 === '1' && M12_4 === '0' && bonus === 'no') {
+                    return new Error("Height too small for number of color-matching Units")
                 }
-                if (M12_1 === '1' && M12_2 === '0' && M12_3 === '1' && bonus === 'no') {
+                if (M12_1 === '1' && M12_4 === '1' && bonus === 'no') {
                     return 15
                 }
-                if (M12_1 === '1' && M12_2 === '0' && M12_3 === '2' && bonus === 'no') {
+                if (M12_1 === '1' && M12_4 === '2' && bonus === 'no') {
                     return 20
                 }
-                if (M12_1 === '1' && M12_2 === '0' && M12_3 === '3' && bonus === 'no') {
+                if (M12_1 === '1' && M12_4 === '3' && bonus === 'no') {
                     return 25
                 }
-                if (M12_1 === '1' && M12_2 === '0' && M12_3 === '4' && bonus === 'no') {
+                if (M12_1 === '1' && M12_4 === '4' && bonus === 'no') {
                     return 30
                 }
-                if (M12_1 === '1' && M12_2 === '0' && M12_3 === '5' && bonus === 'no') {
+                if (M12_1 === '1' && M12_4 === '5' && bonus === 'no') {
                     return 35
                 }
-                if (M12_1 === '1' && M12_2 === '0' && M12_3 === '6' && bonus === 'no') {
+                if (M12_1 === '1' && M12_4 === '6' && bonus === 'no') {
                     return 40
                 }
-                if (M12_1 === '1' && M12_2 === '0' && M12_3 === '7' && bonus === 'no') {
+                if (M12_1 === '1' && M12_4 === '7' && bonus === 'no') {
                     return 45
                 }
-                if (M12_1 === '1' && M12_2 === '0' && M12_3 === '8' && bonus === 'no') {
+                if (M12_1 === '1' && M12_4 === '8' && bonus === 'no') {
                     return 50
                 }
-                if (M12_1 === '1' && M12_2 === '0' && M12_3 === '9' && bonus === 'no') {
+                if (M12_1 === '1' && M12_4 === '9' && bonus === 'no') {
                     return 55
                 }
-                if (M12_1 === '1' && M12_2 === '1' && M12_3 === '0' && bonus === 'no') {
+                if (M12_1 === '1' && M12_4 === '10' && bonus === 'no') {
                     return 60
                 }
-                if (M12_1 === '1' && M12_2 === '1' && M12_3 === '1' && bonus === 'no') {
+                if (M12_1 === '1' && M12_4 === '11' && bonus === 'no') {
                     return 65
                 }
-                if (M12_1 === '1' && M12_2 === '1' && M12_3 === '2' && bonus === 'no') {
+                if (M12_1 === '1' && M12_4 === '12' && bonus === 'no') {
                     return 70
                 }
-                if (M12_1 === '1' && M12_2 === '1' && M12_3 === '3' && bonus === 'no') {
+                if (M12_1 === '1' && M12_4 === '13' && bonus === 'no') {
                     return 75
                 }
-                if (M12_1 === '1' && M12_2 === '1' && M12_3 === '4' && bonus === 'no') {
+                if (M12_1 === '1' && M12_4 === '14' && bonus === 'no') {
                     return 80
                 }
-                if (M12_1 === '1' && M12_2 === '1' && M12_3 === '5' && bonus === 'no') {
+                if (M12_1 === '1' && M12_4 === '15' && bonus === 'no') {
                     return 85
                 }
-                if (M12_1 === '1' && M12_2 === '1' && M12_3 === '6' && bonus === 'no') {
+                if (M12_1 === '1' && M12_4 === '16' && bonus === 'no') {
                     return 90
                 }
-                if (M12_1 === '1' && M12_2 === '1' && M12_3 === '7' && bonus === 'no') {
+                if (M12_1 === '1' && M12_4 === '17' && bonus === 'no') {
                     return 95
                 }
-                if (M12_1 === '1' && M12_2 === '1' && M12_3 === '8' && bonus === 'no') {
+                if (M12_1 === '1' && M12_4 === '18' && bonus === 'no') {
                     return 100
                 }
-                if (M12_1 === '1' && M12_2 === '1' && M12_3 === '9' && bonus === 'no') {
+                if (M12_1 === '1' && M12_4 === '19' && bonus === 'no') {
                     return 105
                 }
-                if (M12_1 === '1' && M12_2 === '2' && M12_3 === '0' && bonus === 'no') {
+                if (M12_1 === '1' && M12_4 === '20' && bonus === 'no') {
                     return 110
                 }
-                if (M12_1 === '1' && M12_2 === '2' && M12_3 === '1' && bonus === 'no') {
+                if (M12_1 === '1' && M12_4 === '21' && bonus === 'no') {
                     return 115
                 }
-                if (M12_1 === '1' && M12_2 === '2' && M12_3 === '2' && bonus === 'no') {
+                if (M12_1 === '1' && M12_4 === '22' && bonus === 'no') {
                     return 120
                 }
-                if (M12_1 === '1' && M12_2 === '2' && M12_3 === '3' && bonus === 'no') {
+                if (M12_1 === '1' && M12_4 === '23' && bonus === 'no') {
                     return 125
                 }
-                if (M12_1 === '1' && M12_2 === '2' && M12_3 === '4' && bonus === 'no') {
+                if (M12_1 === '1' && M12_4 === '24' && bonus === 'no') {
                     return 130
                 }
-                if (M12_1 === '1' && M12_2 === '2' && M12_3 === '5' && bonus === 'no') {
+                if (M12_1 === '1' && M12_4 === '25' && bonus === 'no') {
                     return 135
                 }
-                if (M12_1 === '1' && M12_2 === '2' && M12_3 === '6' && bonus === 'no') {
+                if (M12_1 === '1' && M12_4 === '26' && bonus === 'no') {
                     return 140
                 }
-                if (M12_1 === '1' && M12_2 === '2' && M12_3 === '7' && bonus === 'no') {
+                if (M12_1 === '1' && M12_4 === '27' && bonus === 'no') {
                     return 145
                 }
-                if (M12_1 === '1' && M12_2 === '2' && M12_3 === '8' && bonus === 'no') {
+                if (M12_1 === '1' && M12_4 === '28' && bonus === 'no') {
                     return 150
                 }
-                if (M12_1 === '1' && M12_2 === '2' && M12_3 === '9' && bonus === 'no') {
-                    return new Error("Too many levels")
-                }
-                if (M12_1 === '2' && M12_2 === '0' && M12_3 === '0' && bonus === 'no') {
-                    return 20
-                }
-                if (M12_1 === '2' && M12_2 === '0' && M12_3 === '1' && bonus === 'no') {
-                    return 25
-                }
-                if (M12_1 === '2' && M12_2 === '0' && M12_3 === '2' && bonus === 'no') {
-                    return 30
-                }
-                if (M12_1 === '2' && M12_2 === '0' && M12_3 === '3' && bonus === 'no') {
-                    return 35
-                }
-                if (M12_1 === '2' && M12_2 === '0' && M12_3 === '4' && bonus === 'no') {
-                    return 40
-                }
-                if (M12_1 === '2' && M12_2 === '0' && M12_3 === '5' && bonus === 'no') {
-                    return 45
-                }
-                if (M12_1 === '2' && M12_2 === '0' && M12_3 === '6' && bonus === 'no') {
-                    return 50
-                }
-                if (M12_1 === '2' && M12_2 === '0' && M12_3 === '7' && bonus === 'no') {
-                    return 55
-                }
-                if (M12_1 === '2' && M12_2 === '0' && M12_3 === '8' && bonus === 'no') {
-                    return 60
-                }
-                if (M12_1 === '2' && M12_2 === '0' && M12_3 === '9' && bonus === 'no') {
-                    return 65
-                }
-                if (M12_1 === '2' && M12_2 === '1' && M12_3 === '0' && bonus === 'no') {
-                    return 70
-                }
-                if (M12_1 === '2' && M12_2 === '1' && M12_3 === '1' && bonus === 'no') {
-                    return 75
-                }
-                if (M12_1 === '2' && M12_2 === '1' && M12_3 === '2' && bonus === 'no') {
-                    return 80
-                }
-                if (M12_1 === '2' && M12_2 === '1' && M12_3 === '3' && bonus === 'no') {
-                    return 85
-                }
-                if (M12_1 === '2' && M12_2 === '1' && M12_3 === '4' && bonus === 'no') {
-                    return 90
-                }
-                if (M12_1 === '2' && M12_2 === '1' && M12_3 === '5' && bonus === 'no') {
-                    return 95
-                }
-                if (M12_1 === '2' && M12_2 === '1' && M12_3 === '6' && bonus === 'no') {
-                    return 100
-                }
-                if (M12_1 === '2' && M12_2 === '1' && M12_3 === '7' && bonus === 'no') {
-                    return 105
-                }
-                if (M12_1 === '2' && M12_2 === '1' && M12_3 === '8' && bonus === 'no') {
-                    return 110
-                }
-                if (M12_1 === '2' && M12_2 === '1' && M12_3 === '9' && bonus === 'no') {
-                    return 115
-                }
-                if (M12_1 === '2' && M12_2 === '2' && M12_3 === '0' && bonus === 'no') {
-                    return 120
-                }
-                if (M12_1 === '2' && M12_2 === '2' && M12_3 === '1' && bonus === 'no') {
-                    return 125
-                }
-                if (M12_1 === '2' && M12_2 === '2' && M12_3 === '2' && bonus === 'no') {
-                    return 130
-                }
-                if (M12_1 === '2' && M12_2 === '2' && M12_3 === '3' && bonus === 'no') {
-                    return 135
-                }
-                if (M12_1 === '2' && M12_2 === '2' && M12_3 === '4' && bonus === 'no') {
-                    return 140
-                }
-                if (M12_1 === '2' && M12_2 === '2' && M12_3 === '5' && bonus === 'no') {
-                    return 145
-                }
-                if (M12_1 === '2' && M12_2 === '2' && M12_3 === '6' && bonus === 'no') {
-                    return 150
-                }
-                if (M12_1 === '2' && M12_2 === '2' && M12_3 === '7' && bonus === 'no') {
+                if (M12_1 === '1' && M12_4 === '29' && bonus === 'no') {
                     return 155
                 }
-                if (M12_1 === '2' && M12_2 === '2' && M12_3 === '8' && bonus === 'no') {
-                    return 160
+                if (M12_1 === '2' && M12_4 === '0' && bonus === 'no') {
+                    return new Error("Height too small for number of color-matching Units")
                 }
-                if (M12_1 === '2' && M12_2 === '2' && M12_3 === '9' && bonus === 'no') {
-                    return new Error("Too many levels")
+                if (M12_1 === '2' && M12_4 === '1' && bonus === 'no') {
+                    return new Error("Height too small for number of color-matching Units")
                 }
-                if (M12_1 === '3' && M12_2 === '0' && M12_3 === '0' && bonus === 'no') {
-                    return 30
+                if (M12_1 === '2' && M12_4 === '2' && bonus === 'no') {
+                    return new Error("Height too small for number of color-matching Units")
                 }
-                if (M12_1 === '3' && M12_2 === '0' && M12_3 === '1' && bonus === 'no') {
+                if (M12_1 === '2' && M12_4 === '3' && bonus === 'no') {
                     return 35
                 }
-                if (M12_1 === '3' && M12_2 === '0' && M12_3 === '2' && bonus === 'no') {
+                if (M12_1 === '2' && M12_4 === '4' && bonus === 'no') {
                     return 40
                 }
-                if (M12_1 === '3' && M12_2 === '0' && M12_3 === '3' && bonus === 'no') {
+                if (M12_1 === '2' && M12_4 === '5' && bonus === 'no') {
                     return 45
                 }
-                if (M12_1 === '3' && M12_2 === '0' && M12_3 === '4' && bonus === 'no') {
+                if (M12_1 === '2' && M12_4 === '6' && bonus === 'no') {
                     return 50
                 }
-                if (M12_1 === '3' && M12_2 === '0' && M12_3 === '5' && bonus === 'no') {
+                if (M12_1 === '2' && M12_4 === '7' && bonus === 'no') {
                     return 55
                 }
-                if (M12_1 === '3' && M12_2 === '0' && M12_3 === '6' && bonus === 'no') {
+                if (M12_1 === '2' && M12_4 === '8' && bonus === 'no') {
                     return 60
                 }
-                if (M12_1 === '3' && M12_2 === '0' && M12_3 === '7' && bonus === 'no') {
+                if (M12_1 === '2' && M12_4 === '9' && bonus === 'no') {
                     return 65
                 }
-                if (M12_1 === '3' && M12_2 === '0' && M12_3 === '8' && bonus === 'no') {
+                if (M12_1 === '2' && M12_4 === '10' && bonus === 'no') {
                     return 70
                 }
-                if (M12_1 === '3' && M12_2 === '0' && M12_3 === '9' && bonus === 'no') {
+                if (M12_1 === '2' && M12_4 === '11' && bonus === 'no') {
                     return 75
                 }
-                if (M12_1 === '3' && M12_2 === '1' && M12_3 === '0' && bonus === 'no') {
+                if (M12_1 === '2' && M12_4 === '12' && bonus === 'no') {
                     return 80
                 }
-                if (M12_1 === '3' && M12_2 === '1' && M12_3 === '1' && bonus === 'no') {
+                if (M12_1 === '2' && M12_4 === '13' && bonus === 'no') {
                     return 85
                 }
-                if (M12_1 === '3' && M12_2 === '1' && M12_3 === '2' && bonus === 'no') {
+                if (M12_1 === '2' && M12_4 === '14' && bonus === 'no') {
                     return 90
                 }
-                if (M12_1 === '3' && M12_2 === '1' && M12_3 === '3' && bonus === 'no') {
+                if (M12_1 === '2' && M12_4 === '15' && bonus === 'no') {
                     return 95
                 }
-                if (M12_1 === '3' && M12_2 === '1' && M12_3 === '4' && bonus === 'no') {
+                if (M12_1 === '2' && M12_4 === '16' && bonus === 'no') {
                     return 100
                 }
-                if (M12_1 === '3' && M12_2 === '1' && M12_3 === '5' && bonus === 'no') {
+                if (M12_1 === '2' && M12_4 === '17' && bonus === 'no') {
                     return 105
                 }
-                if (M12_1 === '3' && M12_2 === '1' && M12_3 === '6' && bonus === 'no') {
+                if (M12_1 === '2' && M12_4 === '18' && bonus === 'no') {
                     return 110
                 }
-                if (M12_1 === '3' && M12_2 === '1' && M12_3 === '7' && bonus === 'no') {
+                if (M12_1 === '2' && M12_4 === '19' && bonus === 'no') {
                     return 115
                 }
-                if (M12_1 === '3' && M12_2 === '1' && M12_3 === '8' && bonus === 'no') {
+                if (M12_1 === '2' && M12_4 === '20' && bonus === 'no') {
                     return 120
                 }
-                if (M12_1 === '3' && M12_2 === '1' && M12_3 === '9' && bonus === 'no') {
+                if (M12_1 === '2' && M12_4 === '21' && bonus === 'no') {
                     return 125
                 }
-                if (M12_1 === '3' && M12_2 === '2' && M12_3 === '0' && bonus === 'no') {
+                if (M12_1 === '2' && M12_4 === '22' && bonus === 'no') {
                     return 130
                 }
-                if (M12_1 === '3' && M12_2 === '2' && M12_3 === '1' && bonus === 'no') {
+                if (M12_1 === '2' && M12_4 === '23' && bonus === 'no') {
                     return 135
                 }
-                if (M12_1 === '3' && M12_2 === '2' && M12_3 === '2' && bonus === 'no') {
+                if (M12_1 === '2' && M12_4 === '24' && bonus === 'no') {
                     return 140
                 }
-                if (M12_1 === '3' && M12_2 === '2' && M12_3 === '3' && bonus === 'no') {
+                if (M12_1 === '2' && M12_4 === '25' && bonus === 'no') {
                     return 145
                 }
-                if (M12_1 === '3' && M12_2 === '2' && M12_3 === '4' && bonus === 'no') {
+                if (M12_1 === '2' && M12_4 === '26' && bonus === 'no') {
                     return 150
                 }
-                if (M12_1 === '3' && M12_2 === '2' && M12_3 === '5' && bonus === 'no') {
+                if (M12_1 === '2' && M12_4 === '27' && bonus === 'no') {
                     return 155
                 }
-                if (M12_1 === '3' && M12_2 === '2' && M12_3 === '6' && bonus === 'no') {
+                if (M12_1 === '2' && M12_4 === '28' && bonus === 'no') {
                     return 160
                 }
-                if (M12_1 === '3' && M12_2 === '2' && M12_3 === '7' && bonus === 'no') {
+                if (M12_1 === '2' && M12_4 === '29' && bonus === 'no') {
                     return 165
                 }
-                if (M12_1 === '3' && M12_2 === '2' && M12_3 === '8' && bonus === 'no') {
+                if (M12_1 === '3' && M12_4 === '0' && bonus === 'no') {
+                    return new Error("Height too small for number of color-matching Units")
+                }
+                if (M12_1 === '3' && M12_4 === '1' && bonus === 'no') {
+                    return new Error("Height too small for number of color-matching Units")
+                }
+                if (M12_1 === '3' && M12_4 === '2' && bonus === 'no') {
+                    return new Error("Height too small for number of color-matching Units")
+                }
+                if (M12_1 === '3' && M12_4 === '3' && bonus === 'no') {
+                    return new Error("Height too small for number of color-matching Units")
+                }
+                if (M12_1 === '3' && M12_4 === '4' && bonus === 'no') {
+                    return new Error("Height too small for number of color-matching Units")
+                }
+                if (M12_1 === '3' && M12_4 === '5' && bonus === 'no') {
+                    return 55
+                }
+                if (M12_1 === '3' && M12_4 === '6' && bonus === 'no') {
+                    return 60
+                }
+                if (M12_1 === '3' && M12_4 === '7' && bonus === 'no') {
+                    return 65
+                }
+                if (M12_1 === '3' && M12_4 === '8' && bonus === 'no') {
+                    return 70
+                }
+                if (M12_1 === '3' && M12_4 === '9' && bonus === 'no') {
+                    return 75
+                }
+                if (M12_1 === '3' && M12_4 === '10' && bonus === 'no') {
+                    return 80
+                }
+                if (M12_1 === '3' && M12_4 === '11' && bonus === 'no') {
+                    return 85
+                }
+                if (M12_1 === '3' && M12_4 === '12' && bonus === 'no') {
+                    return 90
+                }
+                if (M12_1 === '3' && M12_4 === '13' && bonus === 'no') {
+                    return 95
+                }
+                if (M12_1 === '3' && M12_4 === '14' && bonus === 'no') {
+                    return 100
+                }
+                if (M12_1 === '3' && M12_4 === '15' && bonus === 'no') {
+                    return 105
+                }
+                if (M12_1 === '3' && M12_4 === '16' && bonus === 'no') {
+                    return 110
+                }
+                if (M12_1 === '3' && M12_4 === '17' && bonus === 'no') {
+                    return 115
+                }
+                if (M12_1 === '3' && M12_4 === '18' && bonus === 'no') {
+                    return 120
+                }
+                if (M12_1 === '3' && M12_4 === '19' && bonus === 'no') {
+                    return 125
+                }
+                if (M12_1 === '3' && M12_4 === '20' && bonus === 'no') {
+                    return 130
+                }
+                if (M12_1 === '3' && M12_4 === '21' && bonus === 'no') {
+                    return 135
+                }
+                if (M12_1 === '3' && M12_4 === '22' && bonus === 'no') {
+                    return 140
+                }
+                if (M12_1 === '3' && M12_4 === '23' && bonus === 'no') {
+                    return 145
+                }
+                if (M12_1 === '3' && M12_4 === '24' && bonus === 'no') {
+                    return 150
+                }
+                if (M12_1 === '3' && M12_4 === '25' && bonus === 'no') {
+                    return 155
+                }
+                if (M12_1 === '3' && M12_4 === '26' && bonus === 'no') {
+                    return 160
+                }
+                if (M12_1 === '3' && M12_4 === '27' && bonus === 'no') {
+                    return 165
+                }
+                if (M12_1 === '3' && M12_4 === '28' && bonus === 'no') {
                     return 170
                 }
-                if (M12_1 === '3' && M12_2 === '2' && M12_3 === '9' && bonus === 'no') {
-                    return new Error("Too many levels")
-                }
-                if (M12_1 === '0' && M12_2 === '0' && M12_3 === '0' && bonus === 'yes') {
-                    return 0
-                }
-                if (M12_1 === '0' && M12_2 === '0' && M12_3 === '1' && bonus === 'yes') {
-                    return 10
-                }
-                if (M12_1 === '0' && M12_2 === '0' && M12_3 === '2' && bonus === 'yes') {
-                    return 15
-                }
-                if (M12_1 === '0' && M12_2 === '0' && M12_3 === '3' && bonus === 'yes') {
-                    return 20
-                }
-                if (M12_1 === '0' && M12_2 === '0' && M12_3 === '4' && bonus === 'yes') {
-                    return 25
-                }
-                if (M12_1 === '0' && M12_2 === '0' && M12_3 === '5' && bonus === 'yes') {
-                    return 30
-                }
-                if (M12_1 === '0' && M12_2 === '0' && M12_3 === '6' && bonus === 'yes') {
-                    return 35
-                }
-                if (M12_1 === '0' && M12_2 === '0' && M12_3 === '7' && bonus === 'yes') {
-                    return 40
-                }
-                if (M12_1 === '0' && M12_2 === '0' && M12_3 === '8' && bonus === 'yes') {
-                    return 45
-                }
-                if (M12_1 === '0' && M12_2 === '0' && M12_3 === '9' && bonus === 'yes') {
-                    return 50
-                }
-                if (M12_1 === '0' && M12_2 === '1' && M12_3 === '0' && bonus === 'yes') {
-                    return 55
-                }
-                if (M12_1 === '0' && M12_2 === '1' && M12_3 === '1' && bonus === 'yes') {
-                    return 60
-                }
-                if (M12_1 === '0' && M12_2 === '1' && M12_3 === '2' && bonus === 'yes') {
-                    return 65
-                }
-                if (M12_1 === '0' && M12_2 === '1' && M12_3 === '3' && bonus === 'yes') {
-                    return 70
-                }
-                if (M12_1 === '0' && M12_2 === '1' && M12_3 === '4' && bonus === 'yes') {
-                    return 75
-                }
-                if (M12_1 === '0' && M12_2 === '1' && M12_3 === '5' && bonus === 'yes') {
-                    return 80
-                }
-                if (M12_1 === '0' && M12_2 === '1' && M12_3 === '6' && bonus === 'yes') {
-                    return 85
-                }
-                if (M12_1 === '0' && M12_2 === '1' && M12_3 === '7' && bonus === 'yes') {
-                    return 90
-                }
-                if (M12_1 === '0' && M12_2 === '1' && M12_3 === '8' && bonus === 'yes') {
-                    return 95
-                }
-                if (M12_1 === '0' && M12_2 === '1' && M12_3 === '9' && bonus === 'yes') {
-                    return 100
-                }
-                if (M12_1 === '0' && M12_2 === '2' && M12_3 === '0' && bonus === 'yes') {
-                    return 105
-                }
-                if (M12_1 === '0' && M12_2 === '2' && M12_3 === '1' && bonus === 'yes') {
-                    return 110
-                }
-                if (M12_1 === '0' && M12_2 === '2' && M12_3 === '2' && bonus === 'yes') {
-                    return 115
-                }
-                if (M12_1 === '0' && M12_2 === '2' && M12_3 === '3' && bonus === 'yes') {
-                    return 120
-                }
-                if (M12_1 === '0' && M12_2 === '2' && M12_3 === '4' && bonus === 'yes') {
-                    return 125
-                }
-                if (M12_1 === '0' && M12_2 === '2' && M12_3 === '5' && bonus === 'yes') {
-                    return 130
-                }
-                if (M12_1 === '0' && M12_2 === '2' && M12_3 === '6' && bonus === 'yes') {
-                    return 135
-                }
-                if (M12_1 === '0' && M12_2 === '2' && M12_3 === '7' && bonus === 'yes') {
-                    return 140
-                }
-                if (M12_1 === '0' && M12_2 === '2' && M12_3 === '8' && bonus === 'yes') {
-                    return 145
-                }
-                if (M12_1 === '0' && M12_2 === '2' && M12_3 === '9' && bonus === 'yes') {
-                    return new Error("Too many levels")
-                }
-                if (M12_1 === '1' && M12_2 === '0' && M12_3 === '0' && bonus === 'yes') {
-                    return 15
-                }
-                if (M12_1 === '1' && M12_2 === '0' && M12_3 === '1' && bonus === 'yes') {
-                    return 20
-                }
-                if (M12_1 === '1' && M12_2 === '0' && M12_3 === '2' && bonus === 'yes') {
-                    return 25
-                }
-                if (M12_1 === '1' && M12_2 === '0' && M12_3 === '3' && bonus === 'yes') {
-                    return 30
-                }
-                if (M12_1 === '1' && M12_2 === '0' && M12_3 === '4' && bonus === 'yes') {
-                    return 35
-                }
-                if (M12_1 === '1' && M12_2 === '0' && M12_3 === '5' && bonus === 'yes') {
-                    return 40
-                }
-                if (M12_1 === '1' && M12_2 === '0' && M12_3 === '6' && bonus === 'yes') {
-                    return 45
-                }
-                if (M12_1 === '1' && M12_2 === '0' && M12_3 === '7' && bonus === 'yes') {
-                    return 50
-                }
-                if (M12_1 === '1' && M12_2 === '0' && M12_3 === '8' && bonus === 'yes') {
-                    return 55
-                }
-                if (M12_1 === '1' && M12_2 === '0' && M12_3 === '9' && bonus === 'yes') {
-                    return 60
-                }
-                if (M12_1 === '1' && M12_2 === '1' && M12_3 === '0' && bonus === 'yes') {
-                    return 65
-                }
-                if (M12_1 === '1' && M12_2 === '1' && M12_3 === '1' && bonus === 'yes') {
-                    return 70
-                }
-                if (M12_1 === '1' && M12_2 === '1' && M12_3 === '2' && bonus === 'yes') {
-                    return 75
-                }
-                if (M12_1 === '1' && M12_2 === '1' && M12_3 === '3' && bonus === 'yes') {
-                    return 80
-                }
-                if (M12_1 === '1' && M12_2 === '1' && M12_3 === '4' && bonus === 'yes') {
-                    return 85
-                }
-                if (M12_1 === '1' && M12_2 === '1' && M12_3 === '5' && bonus === 'yes') {
-                    return 90
-                }
-                if (M12_1 === '1' && M12_2 === '1' && M12_3 === '6' && bonus === 'yes') {
-                    return 95
-                }
-                if (M12_1 === '1' && M12_2 === '1' && M12_3 === '7' && bonus === 'yes') {
-                    return 100
-                }
-                if (M12_1 === '1' && M12_2 === '1' && M12_3 === '8' && bonus === 'yes') {
-                    return 105
-                }
-                if (M12_1 === '1' && M12_2 === '1' && M12_3 === '9' && bonus === 'yes') {
-                    return 110
-                }
-                if (M12_1 === '1' && M12_2 === '2' && M12_3 === '0' && bonus === 'yes') {
-                    return 115
-                }
-                if (M12_1 === '1' && M12_2 === '2' && M12_3 === '1' && bonus === 'yes') {
-                    return 120
-                }
-                if (M12_1 === '1' && M12_2 === '2' && M12_3 === '2' && bonus === 'yes') {
-                    return 125
-                }
-                if (M12_1 === '1' && M12_2 === '2' && M12_3 === '3' && bonus === 'yes') {
-                    return 130
-                }
-                if (M12_1 === '1' && M12_2 === '2' && M12_3 === '4' && bonus === 'yes') {
-                    return 135
-                }
-                if (M12_1 === '1' && M12_2 === '2' && M12_3 === '5' && bonus === 'yes') {
-                    return 140
-                }
-                if (M12_1 === '1' && M12_2 === '2' && M12_3 === '6' && bonus === 'yes') {
-                    return 145
-                }
-                if (M12_1 === '1' && M12_2 === '2' && M12_3 === '7' && bonus === 'yes') {
-                    return 150
-                }
-                if (M12_1 === '1' && M12_2 === '2' && M12_3 === '8' && bonus === 'yes') {
-                    return 155
-                }
-                if (M12_1 === '1' && M12_2 === '2' && M12_3 === '9' && bonus === 'yes') {
-                    return new Error("Too many levels")
-                }
-                if (M12_1 === '2' && M12_2 === '0' && M12_3 === '0' && bonus === 'yes') {
-                    return 25
-                }
-                if (M12_1 === '2' && M12_2 === '0' && M12_3 === '1' && bonus === 'yes') {
-                    return 30
-                }
-                if (M12_1 === '2' && M12_2 === '0' && M12_3 === '2' && bonus === 'yes') {
-                    return 35
-                }
-                if (M12_1 === '2' && M12_2 === '0' && M12_3 === '3' && bonus === 'yes') {
-                    return 40
-                }
-                if (M12_1 === '2' && M12_2 === '0' && M12_3 === '4' && bonus === 'yes') {
-                    return 45
-                }
-                if (M12_1 === '2' && M12_2 === '0' && M12_3 === '5' && bonus === 'yes') {
-                    return 50
-                }
-                if (M12_1 === '2' && M12_2 === '0' && M12_3 === '6' && bonus === 'yes') {
-                    return 55
-                }
-                if (M12_1 === '2' && M12_2 === '0' && M12_3 === '7' && bonus === 'yes') {
-                    return 60
-                }
-                if (M12_1 === '2' && M12_2 === '0' && M12_3 === '8' && bonus === 'yes') {
-                    return 65
-                }
-                if (M12_1 === '2' && M12_2 === '0' && M12_3 === '9' && bonus === 'yes') {
-                    return 70
-                }
-                if (M12_1 === '2' && M12_2 === '1' && M12_3 === '0' && bonus === 'yes') {
-                    return 75
-                }
-                if (M12_1 === '2' && M12_2 === '1' && M12_3 === '1' && bonus === 'yes') {
-                    return 80
-                }
-                if (M12_1 === '2' && M12_2 === '1' && M12_3 === '2' && bonus === 'yes') {
-                    return 85
-                }
-                if (M12_1 === '2' && M12_2 === '1' && M12_3 === '3' && bonus === 'yes') {
-                    return 90
-                }
-                if (M12_1 === '2' && M12_2 === '1' && M12_3 === '4' && bonus === 'yes') {
-                    return 95
-                }
-                if (M12_1 === '2' && M12_2 === '1' && M12_3 === '5' && bonus === 'yes') {
-                    return 100
-                }
-                if (M12_1 === '2' && M12_2 === '1' && M12_3 === '6' && bonus === 'yes') {
-                    return 105
-                }
-                if (M12_1 === '2' && M12_2 === '1' && M12_3 === '7' && bonus === 'yes') {
-                    return 110
-                }
-                if (M12_1 === '2' && M12_2 === '1' && M12_3 === '8' && bonus === 'yes') {
-                    return 115
-                }
-                if (M12_1 === '2' && M12_2 === '1' && M12_3 === '9' && bonus === 'yes') {
-                    return 120
-                }
-                if (M12_1 === '2' && M12_2 === '2' && M12_3 === '0' && bonus === 'yes') {
-                    return 125
-                }
-                if (M12_1 === '2' && M12_2 === '2' && M12_3 === '1' && bonus === 'yes') {
-                    return 130
-                }
-                if (M12_1 === '2' && M12_2 === '2' && M12_3 === '2' && bonus === 'yes') {
-                    return 135
-                }
-                if (M12_1 === '2' && M12_2 === '2' && M12_3 === '3' && bonus === 'yes') {
-                    return 140
-                }
-                if (M12_1 === '2' && M12_2 === '2' && M12_3 === '4' && bonus === 'yes') {
-                    return 145
-                }
-                if (M12_1 === '2' && M12_2 === '2' && M12_3 === '5' && bonus === 'yes') {
-                    return 150
-                }
-                if (M12_1 === '2' && M12_2 === '2' && M12_3 === '6' && bonus === 'yes') {
-                    return 155
-                }
-                if (M12_1 === '2' && M12_2 === '2' && M12_3 === '7' && bonus === 'yes') {
-                    return 160
-                }
-                if (M12_1 === '2' && M12_2 === '2' && M12_3 === '8' && bonus === 'yes') {
-                    return 165
-                }
-                if (M12_1 === '2' && M12_2 === '2' && M12_3 === '9' && bonus === 'yes') {
-                    return new Error("Too many levels")
-                }
-                if (M12_1 === '3' && M12_2 === '0' && M12_3 === '0' && bonus === 'yes') {
-                    return 35
-                }
-                if (M12_1 === '3' && M12_2 === '0' && M12_3 === '1' && bonus === 'yes') {
-                    return 40
-                }
-                if (M12_1 === '3' && M12_2 === '0' && M12_3 === '2' && bonus === 'yes') {
-                    return 45
-                }
-                if (M12_1 === '3' && M12_2 === '0' && M12_3 === '3' && bonus === 'yes') {
-                    return 50
-                }
-                if (M12_1 === '3' && M12_2 === '0' && M12_3 === '4' && bonus === 'yes') {
-                    return 55
-                }
-                if (M12_1 === '3' && M12_2 === '0' && M12_3 === '5' && bonus === 'yes') {
-                    return 60
-                }
-                if (M12_1 === '3' && M12_2 === '0' && M12_3 === '6' && bonus === 'yes') {
-                    return 65
-                }
-                if (M12_1 === '3' && M12_2 === '0' && M12_3 === '7' && bonus === 'yes') {
-                    return 70
-                }
-                if (M12_1 === '3' && M12_2 === '0' && M12_3 === '8' && bonus === 'yes') {
-                    return 75
-                }
-                if (M12_1 === '3' && M12_2 === '0' && M12_3 === '9' && bonus === 'yes') {
-                    return 80
-                }
-                if (M12_1 === '3' && M12_2 === '1' && M12_3 === '0' && bonus === 'yes') {
-                    return 85
-                }
-                if (M12_1 === '3' && M12_2 === '1' && M12_3 === '1' && bonus === 'yes') {
-                    return 90
-                }
-                if (M12_1 === '3' && M12_2 === '1' && M12_3 === '2' && bonus === 'yes') {
-                    return 95
-                }
-                if (M12_1 === '3' && M12_2 === '1' && M12_3 === '3' && bonus === 'yes') {
-                    return 100
-                }
-                if (M12_1 === '3' && M12_2 === '1' && M12_3 === '4' && bonus === 'yes') {
-                    return 105
-                }
-                if (M12_1 === '3' && M12_2 === '1' && M12_3 === '5' && bonus === 'yes') {
-                    return 110
-                }
-                if (M12_1 === '3' && M12_2 === '1' && M12_3 === '6' && bonus === 'yes') {
-                    return 115
-                }
-                if (M12_1 === '3' && M12_2 === '1' && M12_3 === '7' && bonus === 'yes') {
-                    return 120
-                }
-                if (M12_1 === '3' && M12_2 === '1' && M12_3 === '8' && bonus === 'yes') {
-                    return 125
-                }
-                if (M12_1 === '3' && M12_2 === '1' && M12_3 === '9' && bonus === 'yes') {
-                    return 130
-                }
-                if (M12_1 === '3' && M12_2 === '2' && M12_3 === '0' && bonus === 'yes') {
-                    return 135
-                }
-                if (M12_1 === '3' && M12_2 === '2' && M12_3 === '1' && bonus === 'yes') {
-                    return 140
-                }
-                if (M12_1 === '3' && M12_2 === '2' && M12_3 === '2' && bonus === 'yes') {
-                    return 145
-                }
-                if (M12_1 === '3' && M12_2 === '2' && M12_3 === '3' && bonus === 'yes') {
-                    return 150
-                }
-                if (M12_1 === '3' && M12_2 === '2' && M12_3 === '4' && bonus === 'yes') {
-                    return 155
-                }
-                if (M12_1 === '3' && M12_2 === '2' && M12_3 === '5' && bonus === 'yes') {
-                    return 160
-                }
-                if (M12_1 === '3' && M12_2 === '2' && M12_3 === '6' && bonus === 'yes') {
-                    return 165
-                }
-                if (M12_1 === '3' && M12_2 === '2' && M12_3 === '7' && bonus === 'yes') {
-                    return 170
-                }
-                if (M12_1 === '3' && M12_2 === '2' && M12_3 === '8' && bonus === 'yes') {
+                if (M12_1 === '3' && M12_4 === '29' && bonus === 'no') {
                     return 175
                 }
-                if (M12_1 === '3' && M12_2 === '2' && M12_3 === '9' && bonus === 'yes') {
-                    return new Error("Too many levels")
+                if (M12_1 === '0' && M12_4 === '0' && bonus === 'yes') {
+                    return 0
+                }
+                if (M12_1 === '0' && M12_4 === '1' && bonus === 'yes') {
+                    return 10
+                }
+                if (M12_1 === '0' && M12_4 === '2' && bonus === 'yes') {
+                    return 15
+                }
+                if (M12_1 === '0' && M12_4 === '3' && bonus === 'yes') {
+                    return 20
+                }
+                if (M12_1 === '0' && M12_4 === '4' && bonus === 'yes') {
+                    return 25
+                }
+                if (M12_1 === '0' && M12_4 === '5' && bonus === 'yes') {
+                    return 30
+                }
+                if (M12_1 === '0' && M12_4 === '6' && bonus === 'yes') {
+                    return 35
+                }
+                if (M12_1 === '0' && M12_4 === '7' && bonus === 'yes') {
+                    return 40
+                }
+                if (M12_1 === '0' && M12_4 === '8' && bonus === 'yes') {
+                    return 45
+                }
+                if (M12_1 === '0' && M12_4 === '9' && bonus === 'yes') {
+                    return 50
+                }
+                if (M12_1 === '0' && M12_4 === '10' && bonus === 'yes') {
+                    return 55
+                }
+                if (M12_1 === '0' && M12_4 === '11' && bonus === 'yes') {
+                    return 60
+                }
+                if (M12_1 === '0' && M12_4 === '12' && bonus === 'yes') {
+                    return 65
+                }
+                if (M12_1 === '0' && M12_4 === '13' && bonus === 'yes') {
+                    return 70
+                }
+                if (M12_1 === '0' && M12_4 === '14' && bonus === 'yes') {
+                    return 75
+                }
+                if (M12_1 === '0' && M12_4 === '15' && bonus === 'yes') {
+                    return 80
+                }
+                if (M12_1 === '0' && M12_4 === '16' && bonus === 'yes') {
+                    return 85
+                }
+                if (M12_1 === '0' && M12_4 === '17' && bonus === 'yes') {
+                    return 90
+                }
+                if (M12_1 === '0' && M12_4 === '18' && bonus === 'yes') {
+                    return 95
+                }
+                if (M12_1 === '0' && M12_4 === '19' && bonus === 'yes') {
+                    return 100
+                }
+                if (M12_1 === '0' && M12_4 === '20' && bonus === 'yes') {
+                    return 105
+                }
+                if (M12_1 === '0' && M12_4 === '21' && bonus === 'yes') {
+                    return 110
+                }
+                if (M12_1 === '0' && M12_4 === '22' && bonus === 'yes') {
+                    return 115
+                }
+                if (M12_1 === '0' && M12_4 === '23' && bonus === 'yes') {
+                    return 120
+                }
+                if (M12_1 === '0' && M12_4 === '24' && bonus === 'yes') {
+                    return 125
+                }
+                if (M12_1 === '0' && M12_4 === '25' && bonus === 'yes') {
+                    return 130
+                }
+                if (M12_1 === '0' && M12_4 === '26' && bonus === 'yes') {
+                    return 135
+                }
+                if (M12_1 === '0' && M12_4 === '27' && bonus === 'yes') {
+                    return 140
+                }
+                if (M12_1 === '0' && M12_4 === '28' && bonus === 'yes') {
+                    return 145
+                }
+                if (M12_1 === '0' && M12_4 === '29' && bonus === 'yes') {
+                    return 150
+                }
+                if (M12_1 === '1' && M12_4 === '0' && bonus === 'yes') {
+                    return new Error("Height too small for number of color-matching Units")
+                }
+                if (M12_1 === '1' && M12_4 === '1' && bonus === 'yes') {
+                    return 20
+                }
+                if (M12_1 === '1' && M12_4 === '2' && bonus === 'yes') {
+                    return 25
+                }
+                if (M12_1 === '1' && M12_4 === '3' && bonus === 'yes') {
+                    return 30
+                }
+                if (M12_1 === '1' && M12_4 === '4' && bonus === 'yes') {
+                    return 35
+                }
+                if (M12_1 === '1' && M12_4 === '5' && bonus === 'yes') {
+                    return 40
+                }
+                if (M12_1 === '1' && M12_4 === '6' && bonus === 'yes') {
+                    return 45
+                }
+                if (M12_1 === '1' && M12_4 === '7' && bonus === 'yes') {
+                    return 50
+                }
+                if (M12_1 === '1' && M12_4 === '8' && bonus === 'yes') {
+                    return 55
+                }
+                if (M12_1 === '1' && M12_4 === '9' && bonus === 'yes') {
+                    return 60
+                }
+                if (M12_1 === '1' && M12_4 === '10' && bonus === 'yes') {
+                    return 65
+                }
+                if (M12_1 === '1' && M12_4 === '11' && bonus === 'yes') {
+                    return 70
+                }
+                if (M12_1 === '1' && M12_4 === '12' && bonus === 'yes') {
+                    return 75
+                }
+                if (M12_1 === '1' && M12_4 === '13' && bonus === 'yes') {
+                    return 80
+                }
+                if (M12_1 === '1' && M12_4 === '14' && bonus === 'yes') {
+                    return 85
+                }
+                if (M12_1 === '1' && M12_4 === '15' && bonus === 'yes') {
+                    return 90
+                }
+                if (M12_1 === '1' && M12_4 === '16' && bonus === 'yes') {
+                    return 95
+                }
+                if (M12_1 === '1' && M12_4 === '17' && bonus === 'yes') {
+                    return 100
+                }
+                if (M12_1 === '1' && M12_4 === '18' && bonus === 'yes') {
+                    return 105
+                }
+                if (M12_1 === '1' && M12_4 === '19' && bonus === 'yes') {
+                    return 110
+                }
+                if (M12_1 === '1' && M12_4 === '20' && bonus === 'yes') {
+                    return 115
+                }
+                if (M12_1 === '1' && M12_4 === '21' && bonus === 'yes') {
+                    return 120
+                }
+                if (M12_1 === '1' && M12_4 === '22' && bonus === 'yes') {
+                    return 125
+                }
+                if (M12_1 === '1' && M12_4 === '23' && bonus === 'yes') {
+                    return 130
+                }
+                if (M12_1 === '1' && M12_4 === '24' && bonus === 'yes') {
+                    return 135
+                }
+                if (M12_1 === '1' && M12_4 === '25' && bonus === 'yes') {
+                    return 140
+                }
+                if (M12_1 === '1' && M12_4 === '26' && bonus === 'yes') {
+                    return 145
+                }
+                if (M12_1 === '1' && M12_4 === '27' && bonus === 'yes') {
+                    return 150
+                }
+                if (M12_1 === '1' && M12_4 === '28' && bonus === 'yes') {
+                    return 155
+                }
+                if (M12_1 === '1' && M12_4 === '29' && bonus === 'yes') {
+                    return 160
+                }
+                if (M12_1 === '2' && M12_4 === '0' && bonus === 'yes') {
+                    return new Error("Height too small for number of color-matching Units")
+                }
+                if (M12_1 === '2' && M12_4 === '1' && bonus === 'yes') {
+                    return new Error("Height too small for number of color-matching Units")
+                }
+                if (M12_1 === '2' && M12_4 === '2' && bonus === 'yes') {
+                    return new Error("Height too small for number of color-matching Units")
+                }
+                if (M12_1 === '2' && M12_4 === '3' && bonus === 'yes') {
+                    return 40
+                }
+                if (M12_1 === '2' && M12_4 === '4' && bonus === 'yes') {
+                    return 45
+                }
+                if (M12_1 === '2' && M12_4 === '5' && bonus === 'yes') {
+                    return 50
+                }
+                if (M12_1 === '2' && M12_4 === '6' && bonus === 'yes') {
+                    return 55
+                }
+                if (M12_1 === '2' && M12_4 === '7' && bonus === 'yes') {
+                    return 60
+                }
+                if (M12_1 === '2' && M12_4 === '8' && bonus === 'yes') {
+                    return 65
+                }
+                if (M12_1 === '2' && M12_4 === '9' && bonus === 'yes') {
+                    return 70
+                }
+                if (M12_1 === '2' && M12_4 === '10' && bonus === 'yes') {
+                    return 75
+                }
+                if (M12_1 === '2' && M12_4 === '11' && bonus === 'yes') {
+                    return 80
+                }
+                if (M12_1 === '2' && M12_4 === '12' && bonus === 'yes') {
+                    return 85
+                }
+                if (M12_1 === '2' && M12_4 === '13' && bonus === 'yes') {
+                    return 90
+                }
+                if (M12_1 === '2' && M12_4 === '14' && bonus === 'yes') {
+                    return 95
+                }
+                if (M12_1 === '2' && M12_4 === '15' && bonus === 'yes') {
+                    return 100
+                }
+                if (M12_1 === '2' && M12_4 === '16' && bonus === 'yes') {
+                    return 105
+                }
+                if (M12_1 === '2' && M12_4 === '17' && bonus === 'yes') {
+                    return 110
+                }
+                if (M12_1 === '2' && M12_4 === '18' && bonus === 'yes') {
+                    return 115
+                }
+                if (M12_1 === '2' && M12_4 === '19' && bonus === 'yes') {
+                    return 120
+                }
+                if (M12_1 === '2' && M12_4 === '20' && bonus === 'yes') {
+                    return 125
+                }
+                if (M12_1 === '2' && M12_4 === '21' && bonus === 'yes') {
+                    return 130
+                }
+                if (M12_1 === '2' && M12_4 === '22' && bonus === 'yes') {
+                    return 135
+                }
+                if (M12_1 === '2' && M12_4 === '23' && bonus === 'yes') {
+                    return 140
+                }
+                if (M12_1 === '2' && M12_4 === '24' && bonus === 'yes') {
+                    return 145
+                }
+                if (M12_1 === '2' && M12_4 === '25' && bonus === 'yes') {
+                    return 150
+                }
+                if (M12_1 === '2' && M12_4 === '26' && bonus === 'yes') {
+                    return 155
+                }
+                if (M12_1 === '2' && M12_4 === '27' && bonus === 'yes') {
+                    return 160
+                }
+                if (M12_1 === '2' && M12_4 === '28' && bonus === 'yes') {
+                    return 165
+                }
+                if (M12_1 === '2' && M12_4 === '29' && bonus === 'yes') {
+                    return 170
+                }
+                if (M12_1 === '3' && M12_4 === '0' && bonus === 'yes') {
+                    return new Error("Height too small for number of color-matching Units")
+                }
+                if (M12_1 === '3' && M12_4 === '1' && bonus === 'yes') {
+                    return new Error("Height too small for number of color-matching Units")
+                }
+                if (M12_1 === '3' && M12_4 === '2' && bonus === 'yes') {
+                    return new Error("Height too small for number of color-matching Units")
+                }
+                if (M12_1 === '3' && M12_4 === '3' && bonus === 'yes') {
+                    return new Error("Height too small for number of color-matching Units")
+                }
+                if (M12_1 === '3' && M12_4 === '4' && bonus === 'yes') {
+                    return new Error("Height too small for number of color-matching Units")
+                }
+                if (M12_1 === '3' && M12_4 === '5' && bonus === 'yes') {
+                    return 60
+                }
+                if (M12_1 === '3' && M12_4 === '6' && bonus === 'yes') {
+                    return 65
+                }
+                if (M12_1 === '3' && M12_4 === '7' && bonus === 'yes') {
+                    return 70
+                }
+                if (M12_1 === '3' && M12_4 === '8' && bonus === 'yes') {
+                    return 75
+                }
+                if (M12_1 === '3' && M12_4 === '9' && bonus === 'yes') {
+                    return 80
+                }
+                if (M12_1 === '3' && M12_4 === '10' && bonus === 'yes') {
+                    return 85
+                }
+                if (M12_1 === '3' && M12_4 === '11' && bonus === 'yes') {
+                    return 90
+                }
+                if (M12_1 === '3' && M12_4 === '12' && bonus === 'yes') {
+                    return 95
+                }
+                if (M12_1 === '3' && M12_4 === '13' && bonus === 'yes') {
+                    return 100
+                }
+                if (M12_1 === '3' && M12_4 === '14' && bonus === 'yes') {
+                    return 105
+                }
+                if (M12_1 === '3' && M12_4 === '15' && bonus === 'yes') {
+                    return 110
+                }
+                if (M12_1 === '3' && M12_4 === '16' && bonus === 'yes') {
+                    return 115
+                }
+                if (M12_1 === '3' && M12_4 === '17' && bonus === 'yes') {
+                    return 120
+                }
+                if (M12_1 === '3' && M12_4 === '18' && bonus === 'yes') {
+                    return 125
+                }
+                if (M12_1 === '3' && M12_4 === '19' && bonus === 'yes') {
+                    return 130
+                }
+                if (M12_1 === '3' && M12_4 === '20' && bonus === 'yes') {
+                    return 135
+                }
+                if (M12_1 === '3' && M12_4 === '21' && bonus === 'yes') {
+                    return 140
+                }
+                if (M12_1 === '3' && M12_4 === '22' && bonus === 'yes') {
+                    return 145
+                }
+                if (M12_1 === '3' && M12_4 === '23' && bonus === 'yes') {
+                    return 150
+                }
+                if (M12_1 === '3' && M12_4 === '24' && bonus === 'yes') {
+                    return 155
+                }
+                if (M12_1 === '3' && M12_4 === '25' && bonus === 'yes') {
+                    return 160
+                }
+                if (M12_1 === '3' && M12_4 === '26' && bonus === 'yes') {
+                    return 165
+                }
+                if (M12_1 === '3' && M12_4 === '27' && bonus === 'yes') {
+                    return 170
+                }
+                if (M12_1 === '3' && M12_4 === '28' && bonus === 'yes') {
+                    return 175
+                }
+                if (M12_1 === '3' && M12_4 === '29' && bonus === 'yes') {
+                    return 180
                 }
             }]
         },
@@ -2276,6 +2076,8 @@
                 "type": "enum"
             }],
             "score": [function(M13, bonus) {
+                M13 = String(M13);
+                bonus = String(bonus);
                 if (M13 === '0' && bonus === 'no') {
                     return 0
                 }
@@ -2340,6 +2142,7 @@
                 "type": "enum"
             }],
             "score": [function(precision) {
+                precision = String(precision);
                 if (precision === '0') {
                     return 0
                 }
@@ -2419,16 +2222,16 @@
         "M12-name": "M12 Design and Build",
         "M12-desc": "The Blue Circle is not part of Mission 12.",
         "M12-scoring1": "Number of Circles with a color-matching Unit, flat down on the Mat, and Completely in Circle:",
-        "M12-scoring2": "Sum of heights of all Independent Stacks at least partly in any Circle (tens digit):",
-        "M12-scoring3": "Sum of heights of all Independent Stacks at least partly in any Circle (ones digit):",
-        "M12-error": "Too many levels",
+        "M12-scoring4": "Sum of heights of all Independent Stacks at least partly in any Circle:",
         "M13-name": "M13 Sustainability Upgrades",
         "M13-desc": "Only one Upgrade (solar panels, roof garden, insulation) counts per Stack.",
         "M13-scoring": "Number of Upgrades that are Independent and Supported only by a Stack which is at least partly in a Circle:",
         "precision-name": "M14 Precision",
         "precision-desc": "You are allowed to Interrupt your Robot and bring it back to re-Launch, but Interruptions do lose Precision Tokens.",
         "precision-scoring": "Number of Precision Tokens left on the Field:",
-        "building-unit-error": "Too many building units in use"
+        "building-unit-error": "Too many Building Units in use",
+        "crane-error": "Conflict in position of Blue Units",
+        "M12-error2": "Height too small for number of color-matching Units"
     },
     "rtl": false
 })

--- a/challenges/js/2019_US.js
+++ b/challenges/js/2019_US.js
@@ -53,10 +53,10 @@
                     return 0
                 }
                 if (M01_1 === 'no' && M01_2 === '1' && bonus === 'no') {
-                    return 0
+                    return new Error("Flags raised without Robot on Bridge")
                 }
                 if (M01_1 === 'no' && M01_2 === '2' && bonus === 'no') {
-                    return 0
+                    return new Error("Flags raised without Robot on Bridge")
                 }
                 if (M01_1 === 'yes' && M01_2 === '0' && bonus === 'no') {
                     return 20
@@ -71,10 +71,10 @@
                     return 0
                 }
                 if (M01_1 === 'no' && M01_2 === '1' && bonus === 'yes') {
-                    return 0
+                    return new Error("Flags raised without Robot on Bridge")
                 }
                 if (M01_1 === 'no' && M01_2 === '2' && bonus === 'yes') {
-                    return 0
+                    return new Error("Flags raised without Robot on Bridge")
                 }
                 if (M01_1 === 'yes' && M01_2 === '0' && bonus === 'yes') {
                     return 25
@@ -501,7 +501,7 @@
                     return 205
                 }
                 if (M05_lg === '7' && M05_sm === '10' && bonus === 'no') {
-                    return new Error("Too many Building Units in use")
+                    return 220
                 }
                 if (M05_lg === '8' && M05_sm === '0' && bonus === 'no') {
                     return 80
@@ -531,7 +531,7 @@
                     return 200
                 }
                 if (M05_lg === '8' && M05_sm === '9' && bonus === 'no') {
-                    return new Error("Too many Building Units in use")
+                    return 215
                 }
                 if (M05_lg === '8' && M05_sm === '10' && bonus === 'no') {
                     return new Error("Too many Building Units in use")
@@ -561,7 +561,7 @@
                     return 195
                 }
                 if (M05_lg === '9' && M05_sm === '8' && bonus === 'no') {
-                    return new Error("Too many Building Units in use")
+                    return 210
                 }
                 if (M05_lg === '9' && M05_sm === '9' && bonus === 'no') {
                     return new Error("Too many Building Units in use")
@@ -591,7 +591,7 @@
                     return 190
                 }
                 if (M05_lg === '10' && M05_sm === '7' && bonus === 'no') {
-                    return new Error("Too many Building Units in use")
+                    return 205
                 }
                 if (M05_lg === '10' && M05_sm === '8' && bonus === 'no') {
                     return new Error("Too many Building Units in use")
@@ -864,7 +864,7 @@
                     return 210
                 }
                 if (M05_lg === '7' && M05_sm === '10' && bonus === 'yes') {
-                    return new Error("Too many Building Units in use")
+                    return 225
                 }
                 if (M05_lg === '8' && M05_sm === '0' && bonus === 'yes') {
                     return 85
@@ -894,7 +894,7 @@
                     return 205
                 }
                 if (M05_lg === '8' && M05_sm === '9' && bonus === 'yes') {
-                    return new Error("Too many Building Units in use")
+                    return 220
                 }
                 if (M05_lg === '8' && M05_sm === '10' && bonus === 'yes') {
                     return new Error("Too many Building Units in use")
@@ -924,7 +924,7 @@
                     return 200
                 }
                 if (M05_lg === '9' && M05_sm === '8' && bonus === 'yes') {
-                    return new Error("Too many Building Units in use")
+                    return 215
                 }
                 if (M05_lg === '9' && M05_sm === '9' && bonus === 'yes') {
                     return new Error("Too many Building Units in use")
@@ -954,7 +954,7 @@
                     return 195
                 }
                 if (M05_lg === '10' && M05_sm === '7' && bonus === 'yes') {
-                    return new Error("Too many Building Units in use")
+                    return 210
                 }
                 if (M05_lg === '10' && M05_sm === '8' && bonus === 'yes') {
                     return new Error("Too many Building Units in use")
@@ -2231,6 +2231,7 @@
         "precision-scoring": "Number of Precision Tokens left on the Field:",
         "building-unit-error": "Too many Building Units in use",
         "crane-error": "Conflict in position of Blue Units",
+        "M01-error": "Flags raised without Robot on Bridge",
         "M12-error2": "Height too small for number of color-matching Units"
     },
     "rtl": false

--- a/challenges/xml/2019_US.xml
+++ b/challenges/xml/2019_US.xml
@@ -90,6 +90,7 @@
 
         <string id="building-unit-error">           Too many Building Units in use</string>
         <string id="crane-error">                   Conflict in position of Blue Units</string>
+        <string id="M01-error">                     Flags raised without Robot on Bridge</string>
         <string id="M12-error2">                    Height too small for number of color-matching Units</string>
 
     </strings>
@@ -124,14 +125,14 @@
             </indexes>
             <cases>
                 <case> <index-ref value="no" /><index-ref value="0" /><index-ref value="no" /> <points amount="0"  /> </case>
-                <case> <index-ref value="no" /><index-ref value="1" /><index-ref value="no" /> <points amount="0"  /> </case>
-                <case> <index-ref value="no" /><index-ref value="2" /><index-ref value="no" /> <points amount="0"  /> </case>
+                <case> <index-ref value="no" /><index-ref value="1" /><index-ref value="no" /> <error message="M01-error" /> </case>
+                <case> <index-ref value="no" /><index-ref value="2" /><index-ref value="no" /> <error message="M01-error" /> </case>
                 <case> <index-ref value="yes" /><index-ref value="0" /><index-ref value="no" /> <points amount="20"  /> </case>
                 <case> <index-ref value="yes" /><index-ref value="1" /><index-ref value="no" /> <points amount="35"  /> </case>
                 <case> <index-ref value="yes" /><index-ref value="2" /><index-ref value="no" /> <points amount="50"  /> </case>
                 <case> <index-ref value="no" /><index-ref value="0" /><index-ref value="yes" /> <points amount="0"  /> </case>
-                <case> <index-ref value="no" /><index-ref value="1" /><index-ref value="yes" /> <points amount="0"  /> </case>
-                <case> <index-ref value="no" /><index-ref value="2" /><index-ref value="yes" /> <points amount="0"  /> </case>
+                <case> <index-ref value="no" /><index-ref value="1" /><index-ref value="yes" /> <error message="M01-error" /> </case>
+                <case> <index-ref value="no" /><index-ref value="2" /><index-ref value="yes" /> <error message="M01-error" /> </case>
                 <case> <index-ref value="yes" /><index-ref value="0" /><index-ref value="yes" /> <points amount="25"  /> </case>
                 <case> <index-ref value="yes" /><index-ref value="1" /><index-ref value="yes" /> <points amount="40"  /> </case>
                 <case> <index-ref value="yes" /><index-ref value="2" /><index-ref value="yes" /> <points amount="55"  /> </case>
@@ -305,7 +306,7 @@
 <case> <index-ref value="7" /><index-ref value="7" /><index-ref value="no" /> <points amount="175" /> </case>
 <case> <index-ref value="7" /><index-ref value="8" /><index-ref value="no" /> <points amount="190" /> </case>
 <case> <index-ref value="7" /><index-ref value="9" /><index-ref value="no" /> <points amount="205" /> </case>
-<case> <index-ref value="7" /><index-ref value="10" /><index-ref value="no" /><error message="building-unit-error"  /> </case>
+<case> <index-ref value="7" /><index-ref value="10" /><index-ref value="no" /><points amount="220" /> </case>
 <case> <index-ref value="8" /><index-ref value="0" /><index-ref value="no" /> <points amount="80" /> </case>
 <case> <index-ref value="8" /><index-ref value="1" /><index-ref value="no" /> <points amount="95" /> </case>
 <case> <index-ref value="8" /><index-ref value="2" /><index-ref value="no" /> <points amount="110" /> </case>
@@ -315,7 +316,7 @@
 <case> <index-ref value="8" /><index-ref value="6" /><index-ref value="no" /> <points amount="170" /> </case>
 <case> <index-ref value="8" /><index-ref value="7" /><index-ref value="no" /> <points amount="185" /> </case>
 <case> <index-ref value="8" /><index-ref value="8" /><index-ref value="no" /> <points amount="200" /> </case>
-<case> <index-ref value="8" /><index-ref value="9" /><index-ref value="no" /><error message="building-unit-error"  /> </case>
+<case> <index-ref value="8" /><index-ref value="9" /><index-ref value="no" /> <points amount="215" /> </case>
 <case> <index-ref value="8" /><index-ref value="10" /><index-ref value="no" /><error message="building-unit-error"  /> </case>
 <case> <index-ref value="9" /><index-ref value="0" /><index-ref value="no" /> <points amount="90" /> </case>
 <case> <index-ref value="9" /><index-ref value="1" /><index-ref value="no" /> <points amount="105" /> </case>
@@ -325,7 +326,7 @@
 <case> <index-ref value="9" /><index-ref value="5" /><index-ref value="no" /> <points amount="165" /> </case>
 <case> <index-ref value="9" /><index-ref value="6" /><index-ref value="no" /> <points amount="180" /> </case>
 <case> <index-ref value="9" /><index-ref value="7" /><index-ref value="no" /> <points amount="195" /> </case>
-<case> <index-ref value="9" /><index-ref value="8" /><index-ref value="no" /><error message="building-unit-error"  /> </case>
+<case> <index-ref value="9" /><index-ref value="8" /><index-ref value="no" /> <points amount="210" /> </case>
 <case> <index-ref value="9" /><index-ref value="9" /><index-ref value="no" /><error message="building-unit-error"  /> </case>
 <case> <index-ref value="9" /><index-ref value="10" /><index-ref value="no" /><error message="building-unit-error"  /> </case>
 <case> <index-ref value="10" /><index-ref value="0" /><index-ref value="no" /> <points amount="100" /> </case>
@@ -335,7 +336,7 @@
 <case> <index-ref value="10" /><index-ref value="4" /><index-ref value="no" /> <points amount="160" /> </case>
 <case> <index-ref value="10" /><index-ref value="5" /><index-ref value="no" /> <points amount="175" /> </case>
 <case> <index-ref value="10" /><index-ref value="6" /><index-ref value="no" /> <points amount="190" /> </case>
-<case> <index-ref value="10" /><index-ref value="7" /><index-ref value="no" /><error message="building-unit-error"  /> </case>
+<case> <index-ref value="10" /><index-ref value="7" /><index-ref value="no" /> <points amount="205" /> </case>
 <case> <index-ref value="10" /><index-ref value="8" /><index-ref value="no" /><error message="building-unit-error"  /> </case>
 <case> <index-ref value="10" /><index-ref value="9" /><index-ref value="no" /><error message="building-unit-error"  /> </case>
 <case> <index-ref value="10" /><index-ref value="10" /><index-ref value="no" /><error message="building-unit-error"  /> </case>
@@ -426,7 +427,7 @@
 <case> <index-ref value="7" /><index-ref value="7" /><index-ref value="yes" /> <points amount="180" /> </case>
 <case> <index-ref value="7" /><index-ref value="8" /><index-ref value="yes" /> <points amount="195" /> </case>
 <case> <index-ref value="7" /><index-ref value="9" /><index-ref value="yes" /> <points amount="210" /> </case>
-<case> <index-ref value="7" /><index-ref value="10" /><index-ref value="yes" /><error message="building-unit-error"  /> </case>
+<case> <index-ref value="7" /><index-ref value="10" /><index-ref value="yes" /> <points amount="225" /> </case>
 <case> <index-ref value="8" /><index-ref value="0" /><index-ref value="yes" /> <points amount="85" /> </case>
 <case> <index-ref value="8" /><index-ref value="1" /><index-ref value="yes" /> <points amount="100" /> </case>
 <case> <index-ref value="8" /><index-ref value="2" /><index-ref value="yes" /> <points amount="115" /> </case>
@@ -436,7 +437,7 @@
 <case> <index-ref value="8" /><index-ref value="6" /><index-ref value="yes" /> <points amount="175" /> </case>
 <case> <index-ref value="8" /><index-ref value="7" /><index-ref value="yes" /> <points amount="190" /> </case>
 <case> <index-ref value="8" /><index-ref value="8" /><index-ref value="yes" /> <points amount="205" /> </case>
-<case> <index-ref value="8" /><index-ref value="9" /><index-ref value="yes" /><error message="building-unit-error"  /> </case>
+<case> <index-ref value="8" /><index-ref value="9" /><index-ref value="yes" /> <points amount="220" /> </case>
 <case> <index-ref value="8" /><index-ref value="10" /><index-ref value="yes" /><error message="building-unit-error"  /> </case>
 <case> <index-ref value="9" /><index-ref value="0" /><index-ref value="yes" /> <points amount="95" /> </case>
 <case> <index-ref value="9" /><index-ref value="1" /><index-ref value="yes" /> <points amount="110" /> </case>
@@ -446,7 +447,7 @@
 <case> <index-ref value="9" /><index-ref value="5" /><index-ref value="yes" /> <points amount="170" /> </case>
 <case> <index-ref value="9" /><index-ref value="6" /><index-ref value="yes" /> <points amount="185" /> </case>
 <case> <index-ref value="9" /><index-ref value="7" /><index-ref value="yes" /> <points amount="200" /> </case>
-<case> <index-ref value="9" /><index-ref value="8" /><index-ref value="yes" /><error message="building-unit-error"  /> </case>
+<case> <index-ref value="9" /><index-ref value="8" /><index-ref value="yes" /> <points amount="215" /> </case>
 <case> <index-ref value="9" /><index-ref value="9" /><index-ref value="yes" /><error message="building-unit-error"  /> </case>
 <case> <index-ref value="9" /><index-ref value="10" /><index-ref value="yes" /><error message="building-unit-error"  /> </case>
 <case> <index-ref value="10" /><index-ref value="0" /><index-ref value="yes" /> <points amount="105" /> </case>
@@ -456,7 +457,7 @@
 <case> <index-ref value="10" /><index-ref value="4" /><index-ref value="yes" /> <points amount="165" /> </case>
 <case> <index-ref value="10" /><index-ref value="5" /><index-ref value="yes" /> <points amount="180" /> </case>
 <case> <index-ref value="10" /><index-ref value="6" /><index-ref value="yes" /> <points amount="195" /> </case>
-<case> <index-ref value="10" /><index-ref value="7" /><index-ref value="yes" /><error message="building-unit-error"  /> </case>
+<case> <index-ref value="10" /><index-ref value="7" /><index-ref value="yes" /> <points amount="210" /> </case>
 <case> <index-ref value="10" /><index-ref value="8" /><index-ref value="yes" /><error message="building-unit-error"  /> </case>
 <case> <index-ref value="10" /><index-ref value="9" /><index-ref value="yes" /><error message="building-unit-error"  /> </case>
 <case> <index-ref value="10" /><index-ref value="10" /><index-ref value="yes" /><error message="building-unit-error"  /> </case>

--- a/challenges/xml/2019_US.xml
+++ b/challenges/xml/2019_US.xml
@@ -85,6 +85,7 @@
         <string id="precision-scoring">             Number of Precision Tokens left on the Field:</string>
 
         <string id="building-unit-error">           Too many building units in use</string>
+        <string id="crane-error">                   Conflict in position of hooked Blue Unit</string>
     </strings>
 
     <!-- Do NOT edit below this line -->
@@ -133,8 +134,8 @@
     </mission>
 
     <mission name="M02-name" description="M02-desc">
-        <objective-yesno id="M02-1" description="M02-scoring1" default="no" />
-        <objective-yesno id="M02-2" description="M02-scoring2" default="no" resource="building-unit"/>
+        <objective-yesno id="M02-1" description="M02-scoring1" default="no" resource="building-unit" />
+        <objective-yesno id="M02-2" description="M02-scoring2" default="no" />
         <objective-yesno id="M02-3" description="M02-scoring3" default="no" />
         <score>
             <indexes>
@@ -146,8 +147,8 @@
             <cases>
                 <case> <index-ref value="no" /> <index-ref value="no" /> <index-ref value="no" /><index-ref value="no" /> <points amount="0"  /> </case>
                 <case> <index-ref value="no" /> <index-ref value="no" /> <index-ref value="yes" /><index-ref value="no" /> <points amount="0"  /> </case>
-                <case> <index-ref value="no" /> <index-ref value="yes" /> <index-ref value="no" /><index-ref value="no" /> <points amount="0"  /> </case>
-                <case> <index-ref value="no" /> <index-ref value="yes" /> <index-ref value="yes" /><index-ref value="no" /> <points amount="0"  /> </case>
+                <case> <index-ref value="no" /> <index-ref value="yes" /> <index-ref value="no" /><index-ref value="no" /> <error message="crane-error"  /> </case>
+                <case> <index-ref value="no" /> <index-ref value="yes" /> <index-ref value="yes" /><index-ref value="no" /> <error message="crane-error"  /> </case>
 
                 <case> <index-ref value="yes" /> <index-ref value="no" /> <index-ref value="no" /><index-ref value="no" /> <points amount="20"  /> </case>
                 <case> <index-ref value="yes" /> <index-ref value="no" /> <index-ref value="yes" /><index-ref value="no" /> <points amount="20"  /> </case>
@@ -156,8 +157,8 @@
 
                 <case> <index-ref value="no" /> <index-ref value="no" /> <index-ref value="no" /><index-ref value="yes" /> <points amount="0"  /> </case>
                 <case> <index-ref value="no" /> <index-ref value="no" /> <index-ref value="yes" /><index-ref value="yes" /> <points amount="0"  /> </case>
-                <case> <index-ref value="no" /> <index-ref value="yes" /> <index-ref value="no" /><index-ref value="yes" /> <points amount="0"  /> </case>
-                <case> <index-ref value="no" /> <index-ref value="yes" /> <index-ref value="yes" /><index-ref value="yes" /> <points amount="0"  /> </case>
+                <case> <index-ref value="no" /> <index-ref value="yes" /> <index-ref value="no" /><index-ref value="yes" /> <error message="crane-error"  /> </case>
+                <case> <index-ref value="no" /> <index-ref value="yes" /> <index-ref value="yes" /><index-ref value="yes" /> <error message="crane-error"  /> </case>
 
                 <case> <index-ref value="yes" /> <index-ref value="no" /> <index-ref value="no" /><index-ref value="yes" /> <points amount="30"  /> </case>
                 <case> <index-ref value="yes" /> <index-ref value="no" /> <index-ref value="yes" /><index-ref value="yes" /> <points amount="30"  /> </case>
@@ -318,7 +319,7 @@
 <case> <index-ref value="7" /><index-ref value="7" /><index-ref value="no" /> <points amount="175" /> </case>
 <case> <index-ref value="7" /><index-ref value="8" /><index-ref value="no" /> <points amount="190" /> </case>
 <case> <index-ref value="7" /><index-ref value="9" /><index-ref value="no" /> <points amount="205" /> </case>
-<case> <index-ref value="7" /><index-ref value="10" /><index-ref value="no" /><error message="M12-error"  /> </case>
+<case> <index-ref value="7" /><index-ref value="10" /><index-ref value="no" /><error message="building-unit-error"  /> </case>
 <case> <index-ref value="8" /><index-ref value="0" /><index-ref value="no" /> <points amount="80" /> </case>
 <case> <index-ref value="8" /><index-ref value="1" /><index-ref value="no" /> <points amount="95" /> </case>
 <case> <index-ref value="8" /><index-ref value="2" /><index-ref value="no" /> <points amount="110" /> </case>
@@ -328,8 +329,8 @@
 <case> <index-ref value="8" /><index-ref value="6" /><index-ref value="no" /> <points amount="170" /> </case>
 <case> <index-ref value="8" /><index-ref value="7" /><index-ref value="no" /> <points amount="185" /> </case>
 <case> <index-ref value="8" /><index-ref value="8" /><index-ref value="no" /> <points amount="200" /> </case>
-<case> <index-ref value="8" /><index-ref value="9" /><index-ref value="no" /><error message="M12-error"  /> </case>
-<case> <index-ref value="8" /><index-ref value="10" /><index-ref value="no" /><error message="M12-error"  /> </case>
+<case> <index-ref value="8" /><index-ref value="9" /><index-ref value="no" /><error message="building-unit-error"  /> </case>
+<case> <index-ref value="8" /><index-ref value="10" /><index-ref value="no" /><error message="building-unit-error"  /> </case>
 <case> <index-ref value="9" /><index-ref value="0" /><index-ref value="no" /> <points amount="90" /> </case>
 <case> <index-ref value="9" /><index-ref value="1" /><index-ref value="no" /> <points amount="105" /> </case>
 <case> <index-ref value="9" /><index-ref value="2" /><index-ref value="no" /> <points amount="120" /> </case>
@@ -338,9 +339,9 @@
 <case> <index-ref value="9" /><index-ref value="5" /><index-ref value="no" /> <points amount="165" /> </case>
 <case> <index-ref value="9" /><index-ref value="6" /><index-ref value="no" /> <points amount="180" /> </case>
 <case> <index-ref value="9" /><index-ref value="7" /><index-ref value="no" /> <points amount="195" /> </case>
-<case> <index-ref value="9" /><index-ref value="8" /><index-ref value="no" /><error message="M12-error"  /> </case>
-<case> <index-ref value="9" /><index-ref value="9" /><index-ref value="no" /><error message="M12-error"  /> </case>
-<case> <index-ref value="9" /><index-ref value="10" /><index-ref value="no" /><error message="M12-error"  /> </case>
+<case> <index-ref value="9" /><index-ref value="8" /><index-ref value="no" /><error message="building-unit-error"  /> </case>
+<case> <index-ref value="9" /><index-ref value="9" /><index-ref value="no" /><error message="building-unit-error"  /> </case>
+<case> <index-ref value="9" /><index-ref value="10" /><index-ref value="no" /><error message="building-unit-error"  /> </case>
 <case> <index-ref value="10" /><index-ref value="0" /><index-ref value="no" /> <points amount="100" /> </case>
 <case> <index-ref value="10" /><index-ref value="1" /><index-ref value="no" /> <points amount="115" /> </case>
 <case> <index-ref value="10" /><index-ref value="2" /><index-ref value="no" /> <points amount="130" /> </case>
@@ -348,10 +349,10 @@
 <case> <index-ref value="10" /><index-ref value="4" /><index-ref value="no" /> <points amount="160" /> </case>
 <case> <index-ref value="10" /><index-ref value="5" /><index-ref value="no" /> <points amount="175" /> </case>
 <case> <index-ref value="10" /><index-ref value="6" /><index-ref value="no" /> <points amount="190" /> </case>
-<case> <index-ref value="10" /><index-ref value="7" /><index-ref value="no" /><error message="M12-error"  /> </case>
-<case> <index-ref value="10" /><index-ref value="8" /><index-ref value="no" /><error message="M12-error"  /> </case>
-<case> <index-ref value="10" /><index-ref value="9" /><index-ref value="no" /><error message="M12-error"  /> </case>
-<case> <index-ref value="10" /><index-ref value="10" /><index-ref value="no" /><error message="M12-error"  /> </case>
+<case> <index-ref value="10" /><index-ref value="7" /><index-ref value="no" /><error message="building-unit-error"  /> </case>
+<case> <index-ref value="10" /><index-ref value="8" /><index-ref value="no" /><error message="building-unit-error"  /> </case>
+<case> <index-ref value="10" /><index-ref value="9" /><index-ref value="no" /><error message="building-unit-error"  /> </case>
+<case> <index-ref value="10" /><index-ref value="10" /><index-ref value="no" /><error message="building-unit-error"  /> </case>
 <case> <index-ref value="0" /><index-ref value="0" /><index-ref value="yes" /> <points amount="0" /> </case>
 <case> <index-ref value="0" /><index-ref value="1" /><index-ref value="yes" /> <points amount="20" /> </case>
 <case> <index-ref value="0" /><index-ref value="2" /><index-ref value="yes" /> <points amount="35" /> </case>
@@ -439,7 +440,7 @@
 <case> <index-ref value="7" /><index-ref value="7" /><index-ref value="yes" /> <points amount="180" /> </case>
 <case> <index-ref value="7" /><index-ref value="8" /><index-ref value="yes" /> <points amount="195" /> </case>
 <case> <index-ref value="7" /><index-ref value="9" /><index-ref value="yes" /> <points amount="210" /> </case>
-<case> <index-ref value="7" /><index-ref value="10" /><index-ref value="yes" /><error message="M12-error"  /> </case>
+<case> <index-ref value="7" /><index-ref value="10" /><index-ref value="yes" /><error message="building-unit-error"  /> </case>
 <case> <index-ref value="8" /><index-ref value="0" /><index-ref value="yes" /> <points amount="85" /> </case>
 <case> <index-ref value="8" /><index-ref value="1" /><index-ref value="yes" /> <points amount="100" /> </case>
 <case> <index-ref value="8" /><index-ref value="2" /><index-ref value="yes" /> <points amount="115" /> </case>
@@ -449,8 +450,8 @@
 <case> <index-ref value="8" /><index-ref value="6" /><index-ref value="yes" /> <points amount="175" /> </case>
 <case> <index-ref value="8" /><index-ref value="7" /><index-ref value="yes" /> <points amount="190" /> </case>
 <case> <index-ref value="8" /><index-ref value="8" /><index-ref value="yes" /> <points amount="205" /> </case>
-<case> <index-ref value="8" /><index-ref value="9" /><index-ref value="yes" /><error message="M12-error"  /> </case>
-<case> <index-ref value="8" /><index-ref value="10" /><index-ref value="yes" /><error message="M12-error"  /> </case>
+<case> <index-ref value="8" /><index-ref value="9" /><index-ref value="yes" /><error message="building-unit-error"  /> </case>
+<case> <index-ref value="8" /><index-ref value="10" /><index-ref value="yes" /><error message="building-unit-error"  /> </case>
 <case> <index-ref value="9" /><index-ref value="0" /><index-ref value="yes" /> <points amount="95" /> </case>
 <case> <index-ref value="9" /><index-ref value="1" /><index-ref value="yes" /> <points amount="110" /> </case>
 <case> <index-ref value="9" /><index-ref value="2" /><index-ref value="yes" /> <points amount="125" /> </case>
@@ -459,9 +460,9 @@
 <case> <index-ref value="9" /><index-ref value="5" /><index-ref value="yes" /> <points amount="170" /> </case>
 <case> <index-ref value="9" /><index-ref value="6" /><index-ref value="yes" /> <points amount="185" /> </case>
 <case> <index-ref value="9" /><index-ref value="7" /><index-ref value="yes" /> <points amount="200" /> </case>
-<case> <index-ref value="9" /><index-ref value="8" /><index-ref value="yes" /><error message="M12-error"  /> </case>
-<case> <index-ref value="9" /><index-ref value="9" /><index-ref value="yes" /><error message="M12-error"  /> </case>
-<case> <index-ref value="9" /><index-ref value="10" /><index-ref value="yes" /><error message="M12-error"  /> </case>
+<case> <index-ref value="9" /><index-ref value="8" /><index-ref value="yes" /><error message="building-unit-error"  /> </case>
+<case> <index-ref value="9" /><index-ref value="9" /><index-ref value="yes" /><error message="building-unit-error"  /> </case>
+<case> <index-ref value="9" /><index-ref value="10" /><index-ref value="yes" /><error message="building-unit-error"  /> </case>
 <case> <index-ref value="10" /><index-ref value="0" /><index-ref value="yes" /> <points amount="105" /> </case>
 <case> <index-ref value="10" /><index-ref value="1" /><index-ref value="yes" /> <points amount="120" /> </case>
 <case> <index-ref value="10" /><index-ref value="2" /><index-ref value="yes" /> <points amount="135" /> </case>
@@ -469,10 +470,10 @@
 <case> <index-ref value="10" /><index-ref value="4" /><index-ref value="yes" /> <points amount="165" /> </case>
 <case> <index-ref value="10" /><index-ref value="5" /><index-ref value="yes" /> <points amount="180" /> </case>
 <case> <index-ref value="10" /><index-ref value="6" /><index-ref value="yes" /> <points amount="195" /> </case>
-<case> <index-ref value="10" /><index-ref value="7" /><index-ref value="yes" /><error message="M12-error"  /> </case>
-<case> <index-ref value="10" /><index-ref value="8" /><index-ref value="yes" /><error message="M12-error"  /> </case>
-<case> <index-ref value="10" /><index-ref value="9" /><index-ref value="yes" /><error message="M12-error"  /> </case>
-<case> <index-ref value="10" /><index-ref value="10" /><index-ref value="yes" /><error message="M12-error"  /> </case>
+<case> <index-ref value="10" /><index-ref value="7" /><index-ref value="yes" /><error message="building-unit-error"  /> </case>
+<case> <index-ref value="10" /><index-ref value="8" /><index-ref value="yes" /><error message="building-unit-error"  /> </case>
+<case> <index-ref value="10" /><index-ref value="9" /><index-ref value="yes" /><error message="building-unit-error"  /> </case>
+<case> <index-ref value="10" /><index-ref value="10" /><index-ref value="yes" /><error message="building-unit-error"  /> </case>
             </cases>
         </score>
     </mission>
@@ -639,20 +640,20 @@
         </objective-enum>
         <objective-enum id="M12-2" description="M12-scoring2" default="0" resource="building-unit">
             <option name="0" description="0" resource-use="0" />
-            <option name="1" description="1" resource-use="10" />
-            <option name="2" description="2" resource-use="20" />
+            <option name="1" description="1" resource-use="5" />
+            <option name="2" description="2" resource-use="10" />
         </objective-enum>
         <objective-enum id="M12-3" description="M12-scoring3" default="0" resource="building-unit">
             <option name="0" description="0" resource-use="0" />
             <option name="1" description="1" resource-use="1" />
-            <option name="2" description="2" resource-use="2" />
-            <option name="3" description="3" resource-use="3" />
-            <option name="4" description="4" resource-use="4" />
-            <option name="5" description="5" resource-use="5" />
-            <option name="6" description="6" resource-use="6" />
-            <option name="7" description="7" resource-use="7" />
-            <option name="8" description="8" resource-use="8" />
-            <option name="9" description="9" resource-use="9" />
+            <option name="2" description="2" resource-use="1" />
+            <option name="3" description="3" resource-use="2" />
+            <option name="4" description="4" resource-use="2" />
+            <option name="5" description="5" resource-use="3" />
+            <option name="6" description="6" resource-use="3" />
+            <option name="7" description="7" resource-use="4" />
+            <option name="8" description="8" resource-use="4" />
+            <option name="9" description="9" resource-use="5" />
         </objective-enum>
         <score>
             <indexes>
@@ -691,7 +692,7 @@
 <case> <index-ref value="0" /><index-ref value="2" /><index-ref value="6" /><index-ref value="no" /> <points amount="130" /> </case>
 <case> <index-ref value="0" /><index-ref value="2" /><index-ref value="7" /><index-ref value="no" /> <points amount="135" /> </case>
 <case> <index-ref value="0" /><index-ref value="2" /><index-ref value="8" /><index-ref value="no" /> <points amount="140" /> </case>
-<case> <index-ref value="0" /><index-ref value="2" /><index-ref value="9" /><index-ref value="no" /><error message="M12-error"  /> </case>
+<case> <index-ref value="0" /><index-ref value="2" /><index-ref value="9" /><index-ref value="no" /> <points amount ="145"  /> </case>
 <case> <index-ref value="1" /><index-ref value="0" /><index-ref value="0" /><index-ref value="no" /> <points amount="10" /> </case>
 <case> <index-ref value="1" /><index-ref value="0" /><index-ref value="1" /><index-ref value="no" /> <points amount="15" /> </case>
 <case> <index-ref value="1" /><index-ref value="0" /><index-ref value="2" /><index-ref value="no" /> <points amount="20" /> </case>
@@ -721,7 +722,7 @@
 <case> <index-ref value="1" /><index-ref value="2" /><index-ref value="6" /><index-ref value="no" /> <points amount="140" /> </case>
 <case> <index-ref value="1" /><index-ref value="2" /><index-ref value="7" /><index-ref value="no" /> <points amount="145" /> </case>
 <case> <index-ref value="1" /><index-ref value="2" /><index-ref value="8" /><index-ref value="no" /> <points amount="150" /> </case>
-<case> <index-ref value="1" /><index-ref value="2" /><index-ref value="9" /><index-ref value="no" /><error message="M12-error"  /> </case>
+<case> <index-ref value="1" /><index-ref value="2" /><index-ref value="9" /><index-ref value="no" /> <points amount="155" /> </case>
 <case> <index-ref value="2" /><index-ref value="0" /><index-ref value="0" /><index-ref value="no" /> <points amount="20" /> </case>
 <case> <index-ref value="2" /><index-ref value="0" /><index-ref value="1" /><index-ref value="no" /> <points amount="25" /> </case>
 <case> <index-ref value="2" /><index-ref value="0" /><index-ref value="2" /><index-ref value="no" /> <points amount="30" /> </case>
@@ -751,7 +752,7 @@
 <case> <index-ref value="2" /><index-ref value="2" /><index-ref value="6" /><index-ref value="no" /> <points amount="150" /> </case>
 <case> <index-ref value="2" /><index-ref value="2" /><index-ref value="7" /><index-ref value="no" /> <points amount="155" /> </case>
 <case> <index-ref value="2" /><index-ref value="2" /><index-ref value="8" /><index-ref value="no" /> <points amount="160" /> </case>
-<case> <index-ref value="2" /><index-ref value="2" /><index-ref value="9" /><index-ref value="no" /><error message="M12-error"  /> </case>
+<case> <index-ref value="2" /><index-ref value="2" /><index-ref value="9" /><index-ref value="no" /> <points amount="165"  /> </case>
 <case> <index-ref value="3" /><index-ref value="0" /><index-ref value="0" /><index-ref value="no" /> <points amount="30" /> </case>
 <case> <index-ref value="3" /><index-ref value="0" /><index-ref value="1" /><index-ref value="no" /> <points amount="35" /> </case>
 <case> <index-ref value="3" /><index-ref value="0" /><index-ref value="2" /><index-ref value="no" /> <points amount="40" /> </case>
@@ -781,7 +782,7 @@
 <case> <index-ref value="3" /><index-ref value="2" /><index-ref value="6" /><index-ref value="no" /> <points amount="160" /> </case>
 <case> <index-ref value="3" /><index-ref value="2" /><index-ref value="7" /><index-ref value="no" /> <points amount="165" /> </case>
 <case> <index-ref value="3" /><index-ref value="2" /><index-ref value="8" /><index-ref value="no" /> <points amount="170" /> </case>
-<case> <index-ref value="3" /><index-ref value="2" /><index-ref value="9" /><index-ref value="no" /><error message="M12-error"  /> </case>
+<case> <index-ref value="3" /><index-ref value="2" /><index-ref value="9" /><index-ref value="no" /> <points amount="170"  /> </case>
 <case> <index-ref value="0" /><index-ref value="0" /><index-ref value="0" /><index-ref value="yes" /> <points amount="0" /> </case>
 <case> <index-ref value="0" /><index-ref value="0" /><index-ref value="1" /><index-ref value="yes" /> <points amount="10" /> </case>
 <case> <index-ref value="0" /><index-ref value="0" /><index-ref value="2" /><index-ref value="yes" /> <points amount="15" /> </case>
@@ -811,7 +812,7 @@
 <case> <index-ref value="0" /><index-ref value="2" /><index-ref value="6" /><index-ref value="yes" /> <points amount="135" /> </case>
 <case> <index-ref value="0" /><index-ref value="2" /><index-ref value="7" /><index-ref value="yes" /> <points amount="140" /> </case>
 <case> <index-ref value="0" /><index-ref value="2" /><index-ref value="8" /><index-ref value="yes" /> <points amount="145" /> </case>
-<case> <index-ref value="0" /><index-ref value="2" /><index-ref value="9" /><index-ref value="yes" /><error message="M12-error"  /> </case>
+<case> <index-ref value="0" /><index-ref value="2" /><index-ref value="9" /><index-ref value="yes" /> <points amount="150"  /> </case>
 <case> <index-ref value="1" /><index-ref value="0" /><index-ref value="0" /><index-ref value="yes" /> <points amount="15" /> </case>
 <case> <index-ref value="1" /><index-ref value="0" /><index-ref value="1" /><index-ref value="yes" /> <points amount="20" /> </case>
 <case> <index-ref value="1" /><index-ref value="0" /><index-ref value="2" /><index-ref value="yes" /> <points amount="25" /> </case>
@@ -841,7 +842,7 @@
 <case> <index-ref value="1" /><index-ref value="2" /><index-ref value="6" /><index-ref value="yes" /> <points amount="145" /> </case>
 <case> <index-ref value="1" /><index-ref value="2" /><index-ref value="7" /><index-ref value="yes" /> <points amount="150" /> </case>
 <case> <index-ref value="1" /><index-ref value="2" /><index-ref value="8" /><index-ref value="yes" /> <points amount="155" /> </case>
-<case> <index-ref value="1" /><index-ref value="2" /><index-ref value="9" /><index-ref value="yes" /><error message="M12-error"  /> </case>
+<case> <index-ref value="1" /><index-ref value="2" /><index-ref value="9" /><index-ref value="yes" /> <points amount="160"  /> </case>
 <case> <index-ref value="2" /><index-ref value="0" /><index-ref value="0" /><index-ref value="yes" /> <points amount="25" /> </case>
 <case> <index-ref value="2" /><index-ref value="0" /><index-ref value="1" /><index-ref value="yes" /> <points amount="30" /> </case>
 <case> <index-ref value="2" /><index-ref value="0" /><index-ref value="2" /><index-ref value="yes" /> <points amount="35" /> </case>
@@ -871,7 +872,7 @@
 <case> <index-ref value="2" /><index-ref value="2" /><index-ref value="6" /><index-ref value="yes" /> <points amount="155" /> </case>
 <case> <index-ref value="2" /><index-ref value="2" /><index-ref value="7" /><index-ref value="yes" /> <points amount="160" /> </case>
 <case> <index-ref value="2" /><index-ref value="2" /><index-ref value="8" /><index-ref value="yes" /> <points amount="165" /> </case>
-<case> <index-ref value="2" /><index-ref value="2" /><index-ref value="9" /><index-ref value="yes" /><error message="M12-error"  /> </case>
+<case> <index-ref value="2" /><index-ref value="2" /><index-ref value="9" /><index-ref value="yes" /> <points amount="170"  /> </case>
 <case> <index-ref value="3" /><index-ref value="0" /><index-ref value="0" /><index-ref value="yes" /> <points amount="35" /> </case>
 <case> <index-ref value="3" /><index-ref value="0" /><index-ref value="1" /><index-ref value="yes" /> <points amount="40" /> </case>
 <case> <index-ref value="3" /><index-ref value="0" /><index-ref value="2" /><index-ref value="yes" /> <points amount="45" /> </case>
@@ -901,7 +902,7 @@
 <case> <index-ref value="3" /><index-ref value="2" /><index-ref value="6" /><index-ref value="yes" /> <points amount="165" /> </case>
 <case> <index-ref value="3" /><index-ref value="2" /><index-ref value="7" /><index-ref value="yes" /> <points amount="170" /> </case>
 <case> <index-ref value="3" /><index-ref value="2" /><index-ref value="8" /><index-ref value="yes" /> <points amount="175" /> </case>
-<case> <index-ref value="3" /><index-ref value="2" /><index-ref value="9" /><index-ref value="yes" /><error message="M12-error"  /> </case>            </cases>
+<case> <index-ref value="3" /><index-ref value="2" /><index-ref value="9" /><index-ref value="yes" /> <points amount="180"  /> </case>            </cases>
         </score>
     </mission>
 
@@ -957,7 +958,7 @@
     </mission>
 
     <resources>
-        <resource name="building-unit" quota="20" message="building-unit-error" />
+        <resource name="building-unit" quota="17" message="building-unit-error" />
     </resources>
 
 </fll:challenge>

--- a/challenges/xml/2019_US.xml
+++ b/challenges/xml/2019_US.xml
@@ -2,6 +2,7 @@
 <?xml-stylesheet type="text/xsl" href="../xsl/challenge.xsl"?>
 <fll:challenge
     xmlns:fll="http://fll-tools.com/applications/scoring/v1/challenge.xsd" year="2019" version="0" name="CITY SHAPER">
+    <!-- 2019 Challenge XML version 2, 7 Sept 2019-->
 
     <strings language="en-US">
 
@@ -72,9 +73,12 @@
         <string id="M12-name">                      M12 Design and Build</string>
         <string id="M12-desc">                      <![CDATA[The Blue Circle is not part of Mission 12.]]></string>
         <string id="M12-scoring1">                  Number of Circles with a color-matching Unit, flat down on the Mat, and Completely in Circle:</string>
+<!--
         <string id="M12-scoring2">                  Sum of heights of all Independent Stacks at least partly in any Circle (tens digit):</string>
         <string id="M12-scoring3">                  Sum of heights of all Independent Stacks at least partly in any Circle (ones digit):</string>
         <string id="M12-error">                     Too many levels</string>
+-->
+        <string id="M12-scoring4">                  Sum of heights of all Independent Stacks at least partly in any Circle:</string>
 
         <string id="M13-name">                      M13 Sustainability Upgrades</string>
         <string id="M13-desc">                      <![CDATA[Only one Upgrade (solar panels, roof garden, insulation) counts per Stack.]]></string>
@@ -84,8 +88,10 @@
         <string id="precision-desc">                <![CDATA[You are allowed to Interrupt your Robot and bring it back to re-Launch, but Interruptions do lose Precision Tokens.]]></string>
         <string id="precision-scoring">             Number of Precision Tokens left on the Field:</string>
 
-        <string id="building-unit-error">           Too many building units in use</string>
-        <string id="crane-error">                   Conflict in position of hooked Blue Unit</string>
+        <string id="building-unit-error">           Too many Building Units in use</string>
+        <string id="crane-error">                   Conflict in position of Blue Units</string>
+        <string id="M12-error2">                    Height too small for number of color-matching Units</string>
+
     </strings>
 
     <!-- Do NOT edit below this line -->
@@ -135,7 +141,7 @@
 
     <mission name="M02-name" description="M02-desc">
         <objective-yesno id="M02-1" description="M02-scoring1" default="no" resource="building-unit" />
-        <objective-yesno id="M02-2" description="M02-scoring2" default="no" />
+        <objective-yesno id="M02-2" description="M02-scoring2" default="no" resource="building-unit" />
         <objective-yesno id="M02-3" description="M02-scoring3" default="no" />
         <score>
             <indexes>
@@ -146,22 +152,22 @@
             </indexes>
             <cases>
                 <case> <index-ref value="no" /> <index-ref value="no" /> <index-ref value="no" /><index-ref value="no" /> <points amount="0"  /> </case>
-                <case> <index-ref value="no" /> <index-ref value="no" /> <index-ref value="yes" /><index-ref value="no" /> <points amount="0"  /> </case>
-                <case> <index-ref value="no" /> <index-ref value="yes" /> <index-ref value="no" /><index-ref value="no" /> <error message="crane-error"  /> </case>
-                <case> <index-ref value="no" /> <index-ref value="yes" /> <index-ref value="yes" /><index-ref value="no" /> <error message="crane-error"  /> </case>
+                <case> <index-ref value="no" /> <index-ref value="no" /> <index-ref value="yes" /><index-ref value="no" /> <error message="crane-error" /> </case>
+                <case> <index-ref value="no" /> <index-ref value="yes" /> <index-ref value="no" /><index-ref value="no" /> <error message="crane-error" /> </case>
+                <case> <index-ref value="no" /> <index-ref value="yes" /> <index-ref value="yes" /><index-ref value="no" /> <error message="crane-error" /> </case>
 
                 <case> <index-ref value="yes" /> <index-ref value="no" /> <index-ref value="no" /><index-ref value="no" /> <points amount="20"  /> </case>
-                <case> <index-ref value="yes" /> <index-ref value="no" /> <index-ref value="yes" /><index-ref value="no" /> <points amount="20"  /> </case>
+                <case> <index-ref value="yes" /> <index-ref value="no" /> <index-ref value="yes" /><index-ref value="no" /> <error message="crane-error" /> </case>
                 <case> <index-ref value="yes" /> <index-ref value="yes" /> <index-ref value="no" /><index-ref value="no" /> <points amount="35"  /> </case>
                 <case> <index-ref value="yes" /> <index-ref value="yes" /> <index-ref value="yes" /><index-ref value="no" /> <points amount="50"  /> </case>
 
                 <case> <index-ref value="no" /> <index-ref value="no" /> <index-ref value="no" /><index-ref value="yes" /> <points amount="0"  /> </case>
-                <case> <index-ref value="no" /> <index-ref value="no" /> <index-ref value="yes" /><index-ref value="yes" /> <points amount="0"  /> </case>
-                <case> <index-ref value="no" /> <index-ref value="yes" /> <index-ref value="no" /><index-ref value="yes" /> <error message="crane-error"  /> </case>
-                <case> <index-ref value="no" /> <index-ref value="yes" /> <index-ref value="yes" /><index-ref value="yes" /> <error message="crane-error"  /> </case>
+                <case> <index-ref value="no" /> <index-ref value="no" /> <index-ref value="yes" /><index-ref value="yes" /> <error message="crane-error" /> </case>
+                <case> <index-ref value="no" /> <index-ref value="yes" /> <index-ref value="no" /><index-ref value="yes" /> <error message="crane-error" /> </case>
+                <case> <index-ref value="no" /> <index-ref value="yes" /> <index-ref value="yes" /><index-ref value="yes" /> <error message="crane-error" /> </case>
 
                 <case> <index-ref value="yes" /> <index-ref value="no" /> <index-ref value="no" /><index-ref value="yes" /> <points amount="30"  /> </case>
-                <case> <index-ref value="yes" /> <index-ref value="no" /> <index-ref value="yes" /><index-ref value="yes" /> <points amount="30"  /> </case>
+                <case> <index-ref value="yes" /> <index-ref value="no" /> <index-ref value="yes" /><index-ref value="yes" /> <error message="crane-error" /> </case>
                 <case> <index-ref value="yes" /> <index-ref value="yes" /> <index-ref value="no" /><index-ref value="yes" /> <points amount="45"  /> </case>
                 <case> <index-ref value="yes" /> <index-ref value="yes" /> <index-ref value="yes" /><index-ref value="yes" /> <points amount="60"  /> </case>
             </cases>
@@ -202,28 +208,8 @@
     </mission>
 
     <mission name="M05-name" description="M05-desc">
-        <objective-enum id="M05-lg" description="M05-scoring1" default="0" resource="building-unit" >
-            <option name="0" description="0" resource-use="0" />
-            <option name="1" description="1" resource-use="1" />
-            <option name="2" description="2" resource-use="2" />
-            <option name="3" description="3" resource-use="3" />
-            <option name="4" description="4" resource-use="4" />
-            <option name="5" description="5" resource-use="5" />
-            <option name="6" description="6" resource-use="6" />
-            <option name="7" description="7" resource-use="7" />
-            <option name="8" description="8" resource-use="8" />
-        </objective-enum>
-        <objective-enum id="M05-sm" description="M05-scoring2" default="0" resource="building-unit" >
-            <option name="0" description="0" resource-use="0" />
-            <option name="1" description="1" resource-use="1" />
-            <option name="2" description="2" resource-use="2" />
-            <option name="3" description="3" resource-use="3" />
-            <option name="4" description="4" resource-use="4" />
-            <option name="5" description="5" resource-use="5" />
-            <option name="6" description="6" resource-use="6" />
-            <option name="7" description="7" resource-use="7" />
-            <option name="8" description="8" resource-use="8" />
-        </objective-enum>
+        <objective-number id="M05-lg" description="M05-scoring1" min="0" max="10" default="0" resource="building-unit" />
+        <objective-number id="M05-sm" description="M05-scoring2" min="0" max="10" default="0" resource="building-unit" />
 
         <score>
             <indexes>
@@ -638,271 +624,255 @@
             <option name="2" description="2" />
             <option name="3" description="3" />
         </objective-enum>
-        <objective-enum id="M12-2" description="M12-scoring2" default="0" resource="building-unit">
-            <option name="0" description="0" resource-use="0" />
-            <option name="1" description="1" resource-use="5" />
-            <option name="2" description="2" resource-use="10" />
-        </objective-enum>
-        <objective-enum id="M12-3" description="M12-scoring3" default="0" resource="building-unit">
-            <option name="0" description="0" resource-use="0" />
-            <option name="1" description="1" resource-use="1" />
-            <option name="2" description="2" resource-use="1" />
-            <option name="3" description="3" resource-use="2" />
-            <option name="4" description="4" resource-use="2" />
-            <option name="5" description="5" resource-use="3" />
-            <option name="6" description="6" resource-use="3" />
-            <option name="7" description="7" resource-use="4" />
-            <option name="8" description="8" resource-use="4" />
-            <option name="9" description="9" resource-use="5" />
-        </objective-enum>
+        <objective-number id="M12-4" description="M12-scoring4" min="0" max="29" default="0" resource="building-unit" resource-use="0.5" />
         <score>
             <indexes>
                 <index objective="M12-1" />
-                <index objective="M12-2" />
-                <index objective="M12-3" />
+                <index objective="M12-4" />
                 <index objective="bonus" />
             </indexes>
             <cases>
-<case> <index-ref value="0" /><index-ref value="0" /><index-ref value="0" /><index-ref value="no" /> <points amount="0" /> </case>
-<case> <index-ref value="0" /><index-ref value="0" /><index-ref value="1" /><index-ref value="no" /> <points amount="5" /> </case>
-<case> <index-ref value="0" /><index-ref value="0" /><index-ref value="2" /><index-ref value="no" /> <points amount="10" /> </case>
-<case> <index-ref value="0" /><index-ref value="0" /><index-ref value="3" /><index-ref value="no" /> <points amount="15" /> </case>
-<case> <index-ref value="0" /><index-ref value="0" /><index-ref value="4" /><index-ref value="no" /> <points amount="20" /> </case>
-<case> <index-ref value="0" /><index-ref value="0" /><index-ref value="5" /><index-ref value="no" /> <points amount="25" /> </case>
-<case> <index-ref value="0" /><index-ref value="0" /><index-ref value="6" /><index-ref value="no" /> <points amount="30" /> </case>
-<case> <index-ref value="0" /><index-ref value="0" /><index-ref value="7" /><index-ref value="no" /> <points amount="35" /> </case>
-<case> <index-ref value="0" /><index-ref value="0" /><index-ref value="8" /><index-ref value="no" /> <points amount="40" /> </case>
-<case> <index-ref value="0" /><index-ref value="0" /><index-ref value="9" /><index-ref value="no" /> <points amount="45" /> </case>
-<case> <index-ref value="0" /><index-ref value="1" /><index-ref value="0" /><index-ref value="no" /> <points amount="50" /> </case>
-<case> <index-ref value="0" /><index-ref value="1" /><index-ref value="1" /><index-ref value="no" /> <points amount="55" /> </case>
-<case> <index-ref value="0" /><index-ref value="1" /><index-ref value="2" /><index-ref value="no" /> <points amount="60" /> </case>
-<case> <index-ref value="0" /><index-ref value="1" /><index-ref value="3" /><index-ref value="no" /> <points amount="65" /> </case>
-<case> <index-ref value="0" /><index-ref value="1" /><index-ref value="4" /><index-ref value="no" /> <points amount="70" /> </case>
-<case> <index-ref value="0" /><index-ref value="1" /><index-ref value="5" /><index-ref value="no" /> <points amount="75" /> </case>
-<case> <index-ref value="0" /><index-ref value="1" /><index-ref value="6" /><index-ref value="no" /> <points amount="80" /> </case>
-<case> <index-ref value="0" /><index-ref value="1" /><index-ref value="7" /><index-ref value="no" /> <points amount="85" /> </case>
-<case> <index-ref value="0" /><index-ref value="1" /><index-ref value="8" /><index-ref value="no" /> <points amount="90" /> </case>
-<case> <index-ref value="0" /><index-ref value="1" /><index-ref value="9" /><index-ref value="no" /> <points amount="95" /> </case>
-<case> <index-ref value="0" /><index-ref value="2" /><index-ref value="0" /><index-ref value="no" /> <points amount="100" /> </case>
-<case> <index-ref value="0" /><index-ref value="2" /><index-ref value="1" /><index-ref value="no" /> <points amount="105" /> </case>
-<case> <index-ref value="0" /><index-ref value="2" /><index-ref value="2" /><index-ref value="no" /> <points amount="110" /> </case>
-<case> <index-ref value="0" /><index-ref value="2" /><index-ref value="3" /><index-ref value="no" /> <points amount="115" /> </case>
-<case> <index-ref value="0" /><index-ref value="2" /><index-ref value="4" /><index-ref value="no" /> <points amount="120" /> </case>
-<case> <index-ref value="0" /><index-ref value="2" /><index-ref value="5" /><index-ref value="no" /> <points amount="125" /> </case>
-<case> <index-ref value="0" /><index-ref value="2" /><index-ref value="6" /><index-ref value="no" /> <points amount="130" /> </case>
-<case> <index-ref value="0" /><index-ref value="2" /><index-ref value="7" /><index-ref value="no" /> <points amount="135" /> </case>
-<case> <index-ref value="0" /><index-ref value="2" /><index-ref value="8" /><index-ref value="no" /> <points amount="140" /> </case>
-<case> <index-ref value="0" /><index-ref value="2" /><index-ref value="9" /><index-ref value="no" /> <points amount ="145"  /> </case>
-<case> <index-ref value="1" /><index-ref value="0" /><index-ref value="0" /><index-ref value="no" /> <points amount="10" /> </case>
-<case> <index-ref value="1" /><index-ref value="0" /><index-ref value="1" /><index-ref value="no" /> <points amount="15" /> </case>
-<case> <index-ref value="1" /><index-ref value="0" /><index-ref value="2" /><index-ref value="no" /> <points amount="20" /> </case>
-<case> <index-ref value="1" /><index-ref value="0" /><index-ref value="3" /><index-ref value="no" /> <points amount="25" /> </case>
-<case> <index-ref value="1" /><index-ref value="0" /><index-ref value="4" /><index-ref value="no" /> <points amount="30" /> </case>
-<case> <index-ref value="1" /><index-ref value="0" /><index-ref value="5" /><index-ref value="no" /> <points amount="35" /> </case>
-<case> <index-ref value="1" /><index-ref value="0" /><index-ref value="6" /><index-ref value="no" /> <points amount="40" /> </case>
-<case> <index-ref value="1" /><index-ref value="0" /><index-ref value="7" /><index-ref value="no" /> <points amount="45" /> </case>
-<case> <index-ref value="1" /><index-ref value="0" /><index-ref value="8" /><index-ref value="no" /> <points amount="50" /> </case>
-<case> <index-ref value="1" /><index-ref value="0" /><index-ref value="9" /><index-ref value="no" /> <points amount="55" /> </case>
-<case> <index-ref value="1" /><index-ref value="1" /><index-ref value="0" /><index-ref value="no" /> <points amount="60" /> </case>
-<case> <index-ref value="1" /><index-ref value="1" /><index-ref value="1" /><index-ref value="no" /> <points amount="65" /> </case>
-<case> <index-ref value="1" /><index-ref value="1" /><index-ref value="2" /><index-ref value="no" /> <points amount="70" /> </case>
-<case> <index-ref value="1" /><index-ref value="1" /><index-ref value="3" /><index-ref value="no" /> <points amount="75" /> </case>
-<case> <index-ref value="1" /><index-ref value="1" /><index-ref value="4" /><index-ref value="no" /> <points amount="80" /> </case>
-<case> <index-ref value="1" /><index-ref value="1" /><index-ref value="5" /><index-ref value="no" /> <points amount="85" /> </case>
-<case> <index-ref value="1" /><index-ref value="1" /><index-ref value="6" /><index-ref value="no" /> <points amount="90" /> </case>
-<case> <index-ref value="1" /><index-ref value="1" /><index-ref value="7" /><index-ref value="no" /> <points amount="95" /> </case>
-<case> <index-ref value="1" /><index-ref value="1" /><index-ref value="8" /><index-ref value="no" /> <points amount="100" /> </case>
-<case> <index-ref value="1" /><index-ref value="1" /><index-ref value="9" /><index-ref value="no" /> <points amount="105" /> </case>
-<case> <index-ref value="1" /><index-ref value="2" /><index-ref value="0" /><index-ref value="no" /> <points amount="110" /> </case>
-<case> <index-ref value="1" /><index-ref value="2" /><index-ref value="1" /><index-ref value="no" /> <points amount="115" /> </case>
-<case> <index-ref value="1" /><index-ref value="2" /><index-ref value="2" /><index-ref value="no" /> <points amount="120" /> </case>
-<case> <index-ref value="1" /><index-ref value="2" /><index-ref value="3" /><index-ref value="no" /> <points amount="125" /> </case>
-<case> <index-ref value="1" /><index-ref value="2" /><index-ref value="4" /><index-ref value="no" /> <points amount="130" /> </case>
-<case> <index-ref value="1" /><index-ref value="2" /><index-ref value="5" /><index-ref value="no" /> <points amount="135" /> </case>
-<case> <index-ref value="1" /><index-ref value="2" /><index-ref value="6" /><index-ref value="no" /> <points amount="140" /> </case>
-<case> <index-ref value="1" /><index-ref value="2" /><index-ref value="7" /><index-ref value="no" /> <points amount="145" /> </case>
-<case> <index-ref value="1" /><index-ref value="2" /><index-ref value="8" /><index-ref value="no" /> <points amount="150" /> </case>
-<case> <index-ref value="1" /><index-ref value="2" /><index-ref value="9" /><index-ref value="no" /> <points amount="155" /> </case>
-<case> <index-ref value="2" /><index-ref value="0" /><index-ref value="0" /><index-ref value="no" /> <points amount="20" /> </case>
-<case> <index-ref value="2" /><index-ref value="0" /><index-ref value="1" /><index-ref value="no" /> <points amount="25" /> </case>
-<case> <index-ref value="2" /><index-ref value="0" /><index-ref value="2" /><index-ref value="no" /> <points amount="30" /> </case>
-<case> <index-ref value="2" /><index-ref value="0" /><index-ref value="3" /><index-ref value="no" /> <points amount="35" /> </case>
-<case> <index-ref value="2" /><index-ref value="0" /><index-ref value="4" /><index-ref value="no" /> <points amount="40" /> </case>
-<case> <index-ref value="2" /><index-ref value="0" /><index-ref value="5" /><index-ref value="no" /> <points amount="45" /> </case>
-<case> <index-ref value="2" /><index-ref value="0" /><index-ref value="6" /><index-ref value="no" /> <points amount="50" /> </case>
-<case> <index-ref value="2" /><index-ref value="0" /><index-ref value="7" /><index-ref value="no" /> <points amount="55" /> </case>
-<case> <index-ref value="2" /><index-ref value="0" /><index-ref value="8" /><index-ref value="no" /> <points amount="60" /> </case>
-<case> <index-ref value="2" /><index-ref value="0" /><index-ref value="9" /><index-ref value="no" /> <points amount="65" /> </case>
-<case> <index-ref value="2" /><index-ref value="1" /><index-ref value="0" /><index-ref value="no" /> <points amount="70" /> </case>
-<case> <index-ref value="2" /><index-ref value="1" /><index-ref value="1" /><index-ref value="no" /> <points amount="75" /> </case>
-<case> <index-ref value="2" /><index-ref value="1" /><index-ref value="2" /><index-ref value="no" /> <points amount="80" /> </case>
-<case> <index-ref value="2" /><index-ref value="1" /><index-ref value="3" /><index-ref value="no" /> <points amount="85" /> </case>
-<case> <index-ref value="2" /><index-ref value="1" /><index-ref value="4" /><index-ref value="no" /> <points amount="90" /> </case>
-<case> <index-ref value="2" /><index-ref value="1" /><index-ref value="5" /><index-ref value="no" /> <points amount="95" /> </case>
-<case> <index-ref value="2" /><index-ref value="1" /><index-ref value="6" /><index-ref value="no" /> <points amount="100" /> </case>
-<case> <index-ref value="2" /><index-ref value="1" /><index-ref value="7" /><index-ref value="no" /> <points amount="105" /> </case>
-<case> <index-ref value="2" /><index-ref value="1" /><index-ref value="8" /><index-ref value="no" /> <points amount="110" /> </case>
-<case> <index-ref value="2" /><index-ref value="1" /><index-ref value="9" /><index-ref value="no" /> <points amount="115" /> </case>
-<case> <index-ref value="2" /><index-ref value="2" /><index-ref value="0" /><index-ref value="no" /> <points amount="120" /> </case>
-<case> <index-ref value="2" /><index-ref value="2" /><index-ref value="1" /><index-ref value="no" /> <points amount="125" /> </case>
-<case> <index-ref value="2" /><index-ref value="2" /><index-ref value="2" /><index-ref value="no" /> <points amount="130" /> </case>
-<case> <index-ref value="2" /><index-ref value="2" /><index-ref value="3" /><index-ref value="no" /> <points amount="135" /> </case>
-<case> <index-ref value="2" /><index-ref value="2" /><index-ref value="4" /><index-ref value="no" /> <points amount="140" /> </case>
-<case> <index-ref value="2" /><index-ref value="2" /><index-ref value="5" /><index-ref value="no" /> <points amount="145" /> </case>
-<case> <index-ref value="2" /><index-ref value="2" /><index-ref value="6" /><index-ref value="no" /> <points amount="150" /> </case>
-<case> <index-ref value="2" /><index-ref value="2" /><index-ref value="7" /><index-ref value="no" /> <points amount="155" /> </case>
-<case> <index-ref value="2" /><index-ref value="2" /><index-ref value="8" /><index-ref value="no" /> <points amount="160" /> </case>
-<case> <index-ref value="2" /><index-ref value="2" /><index-ref value="9" /><index-ref value="no" /> <points amount="165"  /> </case>
-<case> <index-ref value="3" /><index-ref value="0" /><index-ref value="0" /><index-ref value="no" /> <points amount="30" /> </case>
-<case> <index-ref value="3" /><index-ref value="0" /><index-ref value="1" /><index-ref value="no" /> <points amount="35" /> </case>
-<case> <index-ref value="3" /><index-ref value="0" /><index-ref value="2" /><index-ref value="no" /> <points amount="40" /> </case>
-<case> <index-ref value="3" /><index-ref value="0" /><index-ref value="3" /><index-ref value="no" /> <points amount="45" /> </case>
-<case> <index-ref value="3" /><index-ref value="0" /><index-ref value="4" /><index-ref value="no" /> <points amount="50" /> </case>
-<case> <index-ref value="3" /><index-ref value="0" /><index-ref value="5" /><index-ref value="no" /> <points amount="55" /> </case>
-<case> <index-ref value="3" /><index-ref value="0" /><index-ref value="6" /><index-ref value="no" /> <points amount="60" /> </case>
-<case> <index-ref value="3" /><index-ref value="0" /><index-ref value="7" /><index-ref value="no" /> <points amount="65" /> </case>
-<case> <index-ref value="3" /><index-ref value="0" /><index-ref value="8" /><index-ref value="no" /> <points amount="70" /> </case>
-<case> <index-ref value="3" /><index-ref value="0" /><index-ref value="9" /><index-ref value="no" /> <points amount="75" /> </case>
-<case> <index-ref value="3" /><index-ref value="1" /><index-ref value="0" /><index-ref value="no" /> <points amount="80" /> </case>
-<case> <index-ref value="3" /><index-ref value="1" /><index-ref value="1" /><index-ref value="no" /> <points amount="85" /> </case>
-<case> <index-ref value="3" /><index-ref value="1" /><index-ref value="2" /><index-ref value="no" /> <points amount="90" /> </case>
-<case> <index-ref value="3" /><index-ref value="1" /><index-ref value="3" /><index-ref value="no" /> <points amount="95" /> </case>
-<case> <index-ref value="3" /><index-ref value="1" /><index-ref value="4" /><index-ref value="no" /> <points amount="100" /> </case>
-<case> <index-ref value="3" /><index-ref value="1" /><index-ref value="5" /><index-ref value="no" /> <points amount="105" /> </case>
-<case> <index-ref value="3" /><index-ref value="1" /><index-ref value="6" /><index-ref value="no" /> <points amount="110" /> </case>
-<case> <index-ref value="3" /><index-ref value="1" /><index-ref value="7" /><index-ref value="no" /> <points amount="115" /> </case>
-<case> <index-ref value="3" /><index-ref value="1" /><index-ref value="8" /><index-ref value="no" /> <points amount="120" /> </case>
-<case> <index-ref value="3" /><index-ref value="1" /><index-ref value="9" /><index-ref value="no" /> <points amount="125" /> </case>
-<case> <index-ref value="3" /><index-ref value="2" /><index-ref value="0" /><index-ref value="no" /> <points amount="130" /> </case>
-<case> <index-ref value="3" /><index-ref value="2" /><index-ref value="1" /><index-ref value="no" /> <points amount="135" /> </case>
-<case> <index-ref value="3" /><index-ref value="2" /><index-ref value="2" /><index-ref value="no" /> <points amount="140" /> </case>
-<case> <index-ref value="3" /><index-ref value="2" /><index-ref value="3" /><index-ref value="no" /> <points amount="145" /> </case>
-<case> <index-ref value="3" /><index-ref value="2" /><index-ref value="4" /><index-ref value="no" /> <points amount="150" /> </case>
-<case> <index-ref value="3" /><index-ref value="2" /><index-ref value="5" /><index-ref value="no" /> <points amount="155" /> </case>
-<case> <index-ref value="3" /><index-ref value="2" /><index-ref value="6" /><index-ref value="no" /> <points amount="160" /> </case>
-<case> <index-ref value="3" /><index-ref value="2" /><index-ref value="7" /><index-ref value="no" /> <points amount="165" /> </case>
-<case> <index-ref value="3" /><index-ref value="2" /><index-ref value="8" /><index-ref value="no" /> <points amount="170" /> </case>
-<case> <index-ref value="3" /><index-ref value="2" /><index-ref value="9" /><index-ref value="no" /> <points amount="170"  /> </case>
-<case> <index-ref value="0" /><index-ref value="0" /><index-ref value="0" /><index-ref value="yes" /> <points amount="0" /> </case>
-<case> <index-ref value="0" /><index-ref value="0" /><index-ref value="1" /><index-ref value="yes" /> <points amount="10" /> </case>
-<case> <index-ref value="0" /><index-ref value="0" /><index-ref value="2" /><index-ref value="yes" /> <points amount="15" /> </case>
-<case> <index-ref value="0" /><index-ref value="0" /><index-ref value="3" /><index-ref value="yes" /> <points amount="20" /> </case>
-<case> <index-ref value="0" /><index-ref value="0" /><index-ref value="4" /><index-ref value="yes" /> <points amount="25" /> </case>
-<case> <index-ref value="0" /><index-ref value="0" /><index-ref value="5" /><index-ref value="yes" /> <points amount="30" /> </case>
-<case> <index-ref value="0" /><index-ref value="0" /><index-ref value="6" /><index-ref value="yes" /> <points amount="35" /> </case>
-<case> <index-ref value="0" /><index-ref value="0" /><index-ref value="7" /><index-ref value="yes" /> <points amount="40" /> </case>
-<case> <index-ref value="0" /><index-ref value="0" /><index-ref value="8" /><index-ref value="yes" /> <points amount="45" /> </case>
-<case> <index-ref value="0" /><index-ref value="0" /><index-ref value="9" /><index-ref value="yes" /> <points amount="50" /> </case>
-<case> <index-ref value="0" /><index-ref value="1" /><index-ref value="0" /><index-ref value="yes" /> <points amount="55" /> </case>
-<case> <index-ref value="0" /><index-ref value="1" /><index-ref value="1" /><index-ref value="yes" /> <points amount="60" /> </case>
-<case> <index-ref value="0" /><index-ref value="1" /><index-ref value="2" /><index-ref value="yes" /> <points amount="65" /> </case>
-<case> <index-ref value="0" /><index-ref value="1" /><index-ref value="3" /><index-ref value="yes" /> <points amount="70" /> </case>
-<case> <index-ref value="0" /><index-ref value="1" /><index-ref value="4" /><index-ref value="yes" /> <points amount="75" /> </case>
-<case> <index-ref value="0" /><index-ref value="1" /><index-ref value="5" /><index-ref value="yes" /> <points amount="80" /> </case>
-<case> <index-ref value="0" /><index-ref value="1" /><index-ref value="6" /><index-ref value="yes" /> <points amount="85" /> </case>
-<case> <index-ref value="0" /><index-ref value="1" /><index-ref value="7" /><index-ref value="yes" /> <points amount="90" /> </case>
-<case> <index-ref value="0" /><index-ref value="1" /><index-ref value="8" /><index-ref value="yes" /> <points amount="95" /> </case>
-<case> <index-ref value="0" /><index-ref value="1" /><index-ref value="9" /><index-ref value="yes" /> <points amount="100" /> </case>
-<case> <index-ref value="0" /><index-ref value="2" /><index-ref value="0" /><index-ref value="yes" /> <points amount="105" /> </case>
-<case> <index-ref value="0" /><index-ref value="2" /><index-ref value="1" /><index-ref value="yes" /> <points amount="110" /> </case>
-<case> <index-ref value="0" /><index-ref value="2" /><index-ref value="2" /><index-ref value="yes" /> <points amount="115" /> </case>
-<case> <index-ref value="0" /><index-ref value="2" /><index-ref value="3" /><index-ref value="yes" /> <points amount="120" /> </case>
-<case> <index-ref value="0" /><index-ref value="2" /><index-ref value="4" /><index-ref value="yes" /> <points amount="125" /> </case>
-<case> <index-ref value="0" /><index-ref value="2" /><index-ref value="5" /><index-ref value="yes" /> <points amount="130" /> </case>
-<case> <index-ref value="0" /><index-ref value="2" /><index-ref value="6" /><index-ref value="yes" /> <points amount="135" /> </case>
-<case> <index-ref value="0" /><index-ref value="2" /><index-ref value="7" /><index-ref value="yes" /> <points amount="140" /> </case>
-<case> <index-ref value="0" /><index-ref value="2" /><index-ref value="8" /><index-ref value="yes" /> <points amount="145" /> </case>
-<case> <index-ref value="0" /><index-ref value="2" /><index-ref value="9" /><index-ref value="yes" /> <points amount="150"  /> </case>
-<case> <index-ref value="1" /><index-ref value="0" /><index-ref value="0" /><index-ref value="yes" /> <points amount="15" /> </case>
-<case> <index-ref value="1" /><index-ref value="0" /><index-ref value="1" /><index-ref value="yes" /> <points amount="20" /> </case>
-<case> <index-ref value="1" /><index-ref value="0" /><index-ref value="2" /><index-ref value="yes" /> <points amount="25" /> </case>
-<case> <index-ref value="1" /><index-ref value="0" /><index-ref value="3" /><index-ref value="yes" /> <points amount="30" /> </case>
-<case> <index-ref value="1" /><index-ref value="0" /><index-ref value="4" /><index-ref value="yes" /> <points amount="35" /> </case>
-<case> <index-ref value="1" /><index-ref value="0" /><index-ref value="5" /><index-ref value="yes" /> <points amount="40" /> </case>
-<case> <index-ref value="1" /><index-ref value="0" /><index-ref value="6" /><index-ref value="yes" /> <points amount="45" /> </case>
-<case> <index-ref value="1" /><index-ref value="0" /><index-ref value="7" /><index-ref value="yes" /> <points amount="50" /> </case>
-<case> <index-ref value="1" /><index-ref value="0" /><index-ref value="8" /><index-ref value="yes" /> <points amount="55" /> </case>
-<case> <index-ref value="1" /><index-ref value="0" /><index-ref value="9" /><index-ref value="yes" /> <points amount="60" /> </case>
-<case> <index-ref value="1" /><index-ref value="1" /><index-ref value="0" /><index-ref value="yes" /> <points amount="65" /> </case>
-<case> <index-ref value="1" /><index-ref value="1" /><index-ref value="1" /><index-ref value="yes" /> <points amount="70" /> </case>
-<case> <index-ref value="1" /><index-ref value="1" /><index-ref value="2" /><index-ref value="yes" /> <points amount="75" /> </case>
-<case> <index-ref value="1" /><index-ref value="1" /><index-ref value="3" /><index-ref value="yes" /> <points amount="80" /> </case>
-<case> <index-ref value="1" /><index-ref value="1" /><index-ref value="4" /><index-ref value="yes" /> <points amount="85" /> </case>
-<case> <index-ref value="1" /><index-ref value="1" /><index-ref value="5" /><index-ref value="yes" /> <points amount="90" /> </case>
-<case> <index-ref value="1" /><index-ref value="1" /><index-ref value="6" /><index-ref value="yes" /> <points amount="95" /> </case>
-<case> <index-ref value="1" /><index-ref value="1" /><index-ref value="7" /><index-ref value="yes" /> <points amount="100" /> </case>
-<case> <index-ref value="1" /><index-ref value="1" /><index-ref value="8" /><index-ref value="yes" /> <points amount="105" /> </case>
-<case> <index-ref value="1" /><index-ref value="1" /><index-ref value="9" /><index-ref value="yes" /> <points amount="110" /> </case>
-<case> <index-ref value="1" /><index-ref value="2" /><index-ref value="0" /><index-ref value="yes" /> <points amount="115" /> </case>
-<case> <index-ref value="1" /><index-ref value="2" /><index-ref value="1" /><index-ref value="yes" /> <points amount="120" /> </case>
-<case> <index-ref value="1" /><index-ref value="2" /><index-ref value="2" /><index-ref value="yes" /> <points amount="125" /> </case>
-<case> <index-ref value="1" /><index-ref value="2" /><index-ref value="3" /><index-ref value="yes" /> <points amount="130" /> </case>
-<case> <index-ref value="1" /><index-ref value="2" /><index-ref value="4" /><index-ref value="yes" /> <points amount="135" /> </case>
-<case> <index-ref value="1" /><index-ref value="2" /><index-ref value="5" /><index-ref value="yes" /> <points amount="140" /> </case>
-<case> <index-ref value="1" /><index-ref value="2" /><index-ref value="6" /><index-ref value="yes" /> <points amount="145" /> </case>
-<case> <index-ref value="1" /><index-ref value="2" /><index-ref value="7" /><index-ref value="yes" /> <points amount="150" /> </case>
-<case> <index-ref value="1" /><index-ref value="2" /><index-ref value="8" /><index-ref value="yes" /> <points amount="155" /> </case>
-<case> <index-ref value="1" /><index-ref value="2" /><index-ref value="9" /><index-ref value="yes" /> <points amount="160"  /> </case>
-<case> <index-ref value="2" /><index-ref value="0" /><index-ref value="0" /><index-ref value="yes" /> <points amount="25" /> </case>
-<case> <index-ref value="2" /><index-ref value="0" /><index-ref value="1" /><index-ref value="yes" /> <points amount="30" /> </case>
-<case> <index-ref value="2" /><index-ref value="0" /><index-ref value="2" /><index-ref value="yes" /> <points amount="35" /> </case>
-<case> <index-ref value="2" /><index-ref value="0" /><index-ref value="3" /><index-ref value="yes" /> <points amount="40" /> </case>
-<case> <index-ref value="2" /><index-ref value="0" /><index-ref value="4" /><index-ref value="yes" /> <points amount="45" /> </case>
-<case> <index-ref value="2" /><index-ref value="0" /><index-ref value="5" /><index-ref value="yes" /> <points amount="50" /> </case>
-<case> <index-ref value="2" /><index-ref value="0" /><index-ref value="6" /><index-ref value="yes" /> <points amount="55" /> </case>
-<case> <index-ref value="2" /><index-ref value="0" /><index-ref value="7" /><index-ref value="yes" /> <points amount="60" /> </case>
-<case> <index-ref value="2" /><index-ref value="0" /><index-ref value="8" /><index-ref value="yes" /> <points amount="65" /> </case>
-<case> <index-ref value="2" /><index-ref value="0" /><index-ref value="9" /><index-ref value="yes" /> <points amount="70" /> </case>
-<case> <index-ref value="2" /><index-ref value="1" /><index-ref value="0" /><index-ref value="yes" /> <points amount="75" /> </case>
-<case> <index-ref value="2" /><index-ref value="1" /><index-ref value="1" /><index-ref value="yes" /> <points amount="80" /> </case>
-<case> <index-ref value="2" /><index-ref value="1" /><index-ref value="2" /><index-ref value="yes" /> <points amount="85" /> </case>
-<case> <index-ref value="2" /><index-ref value="1" /><index-ref value="3" /><index-ref value="yes" /> <points amount="90" /> </case>
-<case> <index-ref value="2" /><index-ref value="1" /><index-ref value="4" /><index-ref value="yes" /> <points amount="95" /> </case>
-<case> <index-ref value="2" /><index-ref value="1" /><index-ref value="5" /><index-ref value="yes" /> <points amount="100" /> </case>
-<case> <index-ref value="2" /><index-ref value="1" /><index-ref value="6" /><index-ref value="yes" /> <points amount="105" /> </case>
-<case> <index-ref value="2" /><index-ref value="1" /><index-ref value="7" /><index-ref value="yes" /> <points amount="110" /> </case>
-<case> <index-ref value="2" /><index-ref value="1" /><index-ref value="8" /><index-ref value="yes" /> <points amount="115" /> </case>
-<case> <index-ref value="2" /><index-ref value="1" /><index-ref value="9" /><index-ref value="yes" /> <points amount="120" /> </case>
-<case> <index-ref value="2" /><index-ref value="2" /><index-ref value="0" /><index-ref value="yes" /> <points amount="125" /> </case>
-<case> <index-ref value="2" /><index-ref value="2" /><index-ref value="1" /><index-ref value="yes" /> <points amount="130" /> </case>
-<case> <index-ref value="2" /><index-ref value="2" /><index-ref value="2" /><index-ref value="yes" /> <points amount="135" /> </case>
-<case> <index-ref value="2" /><index-ref value="2" /><index-ref value="3" /><index-ref value="yes" /> <points amount="140" /> </case>
-<case> <index-ref value="2" /><index-ref value="2" /><index-ref value="4" /><index-ref value="yes" /> <points amount="145" /> </case>
-<case> <index-ref value="2" /><index-ref value="2" /><index-ref value="5" /><index-ref value="yes" /> <points amount="150" /> </case>
-<case> <index-ref value="2" /><index-ref value="2" /><index-ref value="6" /><index-ref value="yes" /> <points amount="155" /> </case>
-<case> <index-ref value="2" /><index-ref value="2" /><index-ref value="7" /><index-ref value="yes" /> <points amount="160" /> </case>
-<case> <index-ref value="2" /><index-ref value="2" /><index-ref value="8" /><index-ref value="yes" /> <points amount="165" /> </case>
-<case> <index-ref value="2" /><index-ref value="2" /><index-ref value="9" /><index-ref value="yes" /> <points amount="170"  /> </case>
-<case> <index-ref value="3" /><index-ref value="0" /><index-ref value="0" /><index-ref value="yes" /> <points amount="35" /> </case>
-<case> <index-ref value="3" /><index-ref value="0" /><index-ref value="1" /><index-ref value="yes" /> <points amount="40" /> </case>
-<case> <index-ref value="3" /><index-ref value="0" /><index-ref value="2" /><index-ref value="yes" /> <points amount="45" /> </case>
-<case> <index-ref value="3" /><index-ref value="0" /><index-ref value="3" /><index-ref value="yes" /> <points amount="50" /> </case>
-<case> <index-ref value="3" /><index-ref value="0" /><index-ref value="4" /><index-ref value="yes" /> <points amount="55" /> </case>
-<case> <index-ref value="3" /><index-ref value="0" /><index-ref value="5" /><index-ref value="yes" /> <points amount="60" /> </case>
-<case> <index-ref value="3" /><index-ref value="0" /><index-ref value="6" /><index-ref value="yes" /> <points amount="65" /> </case>
-<case> <index-ref value="3" /><index-ref value="0" /><index-ref value="7" /><index-ref value="yes" /> <points amount="70" /> </case>
-<case> <index-ref value="3" /><index-ref value="0" /><index-ref value="8" /><index-ref value="yes" /> <points amount="75" /> </case>
-<case> <index-ref value="3" /><index-ref value="0" /><index-ref value="9" /><index-ref value="yes" /> <points amount="80" /> </case>
-<case> <index-ref value="3" /><index-ref value="1" /><index-ref value="0" /><index-ref value="yes" /> <points amount="85" /> </case>
-<case> <index-ref value="3" /><index-ref value="1" /><index-ref value="1" /><index-ref value="yes" /> <points amount="90" /> </case>
-<case> <index-ref value="3" /><index-ref value="1" /><index-ref value="2" /><index-ref value="yes" /> <points amount="95" /> </case>
-<case> <index-ref value="3" /><index-ref value="1" /><index-ref value="3" /><index-ref value="yes" /> <points amount="100" /> </case>
-<case> <index-ref value="3" /><index-ref value="1" /><index-ref value="4" /><index-ref value="yes" /> <points amount="105" /> </case>
-<case> <index-ref value="3" /><index-ref value="1" /><index-ref value="5" /><index-ref value="yes" /> <points amount="110" /> </case>
-<case> <index-ref value="3" /><index-ref value="1" /><index-ref value="6" /><index-ref value="yes" /> <points amount="115" /> </case>
-<case> <index-ref value="3" /><index-ref value="1" /><index-ref value="7" /><index-ref value="yes" /> <points amount="120" /> </case>
-<case> <index-ref value="3" /><index-ref value="1" /><index-ref value="8" /><index-ref value="yes" /> <points amount="125" /> </case>
-<case> <index-ref value="3" /><index-ref value="1" /><index-ref value="9" /><index-ref value="yes" /> <points amount="130" /> </case>
-<case> <index-ref value="3" /><index-ref value="2" /><index-ref value="0" /><index-ref value="yes" /> <points amount="135" /> </case>
-<case> <index-ref value="3" /><index-ref value="2" /><index-ref value="1" /><index-ref value="yes" /> <points amount="140" /> </case>
-<case> <index-ref value="3" /><index-ref value="2" /><index-ref value="2" /><index-ref value="yes" /> <points amount="145" /> </case>
-<case> <index-ref value="3" /><index-ref value="2" /><index-ref value="3" /><index-ref value="yes" /> <points amount="150" /> </case>
-<case> <index-ref value="3" /><index-ref value="2" /><index-ref value="4" /><index-ref value="yes" /> <points amount="155" /> </case>
-<case> <index-ref value="3" /><index-ref value="2" /><index-ref value="5" /><index-ref value="yes" /> <points amount="160" /> </case>
-<case> <index-ref value="3" /><index-ref value="2" /><index-ref value="6" /><index-ref value="yes" /> <points amount="165" /> </case>
-<case> <index-ref value="3" /><index-ref value="2" /><index-ref value="7" /><index-ref value="yes" /> <points amount="170" /> </case>
-<case> <index-ref value="3" /><index-ref value="2" /><index-ref value="8" /><index-ref value="yes" /> <points amount="175" /> </case>
-<case> <index-ref value="3" /><index-ref value="2" /><index-ref value="9" /><index-ref value="yes" /> <points amount="180"  /> </case>            </cases>
+            <case> <index-ref value="0" /><index-ref value="0" /><index-ref value="no" /> <points amount="0" /> </case>
+            <case> <index-ref value="0" /><index-ref value="1" /><index-ref value="no" /> <points amount="5" /> </case>
+            <case> <index-ref value="0" /><index-ref value="2" /><index-ref value="no" /> <points amount="10" /> </case>
+            <case> <index-ref value="0" /><index-ref value="3" /><index-ref value="no" /> <points amount="15" /> </case>
+            <case> <index-ref value="0" /><index-ref value="4" /><index-ref value="no" /> <points amount="20" /> </case>
+            <case> <index-ref value="0" /><index-ref value="5" /><index-ref value="no" /> <points amount="25" /> </case>
+            <case> <index-ref value="0" /><index-ref value="6" /><index-ref value="no" /> <points amount="30" /> </case>
+            <case> <index-ref value="0" /><index-ref value="7" /><index-ref value="no" /> <points amount="35" /> </case>
+            <case> <index-ref value="0" /><index-ref value="8" /><index-ref value="no" /> <points amount="40" /> </case>
+            <case> <index-ref value="0" /><index-ref value="9" /><index-ref value="no" /> <points amount="45" /> </case>
+            <case> <index-ref value="0" /><index-ref value="10" /><index-ref value="no" /> <points amount="50" /> </case>
+            <case> <index-ref value="0" /><index-ref value="11" /><index-ref value="no" /> <points amount="55" /> </case>
+            <case> <index-ref value="0" /><index-ref value="12" /><index-ref value="no" /> <points amount="60" /> </case>
+            <case> <index-ref value="0" /><index-ref value="13" /><index-ref value="no" /> <points amount="65" /> </case>
+            <case> <index-ref value="0" /><index-ref value="14" /><index-ref value="no" /> <points amount="70" /> </case>
+            <case> <index-ref value="0" /><index-ref value="15" /><index-ref value="no" /> <points amount="75" /> </case>
+            <case> <index-ref value="0" /><index-ref value="16" /><index-ref value="no" /> <points amount="80" /> </case>
+            <case> <index-ref value="0" /><index-ref value="17" /><index-ref value="no" /> <points amount="85" /> </case>
+            <case> <index-ref value="0" /><index-ref value="18" /><index-ref value="no" /> <points amount="90" /> </case>
+            <case> <index-ref value="0" /><index-ref value="19" /><index-ref value="no" /> <points amount="95" /> </case>
+            <case> <index-ref value="0" /><index-ref value="20" /><index-ref value="no" /> <points amount="100" /> </case>
+            <case> <index-ref value="0" /><index-ref value="21" /><index-ref value="no" /> <points amount="105" /> </case>
+            <case> <index-ref value="0" /><index-ref value="22" /><index-ref value="no" /> <points amount="110" /> </case>
+            <case> <index-ref value="0" /><index-ref value="23" /><index-ref value="no" /> <points amount="115" /> </case>
+            <case> <index-ref value="0" /><index-ref value="24" /><index-ref value="no" /> <points amount="120" /> </case>
+            <case> <index-ref value="0" /><index-ref value="25" /><index-ref value="no" /> <points amount="125" /> </case>
+            <case> <index-ref value="0" /><index-ref value="26" /><index-ref value="no" /> <points amount="130" /> </case>
+            <case> <index-ref value="0" /><index-ref value="27" /><index-ref value="no" /> <points amount="135" /> </case>
+            <case> <index-ref value="0" /><index-ref value="28" /><index-ref value="no" /> <points amount="140" /> </case>
+            <case> <index-ref value="0" /><index-ref value="29" /><index-ref value="no" /> <points amount="145" /> </case>
+            <case> <index-ref value="1" /><index-ref value="0" /><index-ref value="no" /> <error message="M12-error2" /> </case>
+            <case> <index-ref value="1" /><index-ref value="1" /><index-ref value="no" /> <points amount="15" /> </case>
+            <case> <index-ref value="1" /><index-ref value="2" /><index-ref value="no" /> <points amount="20" /> </case>
+            <case> <index-ref value="1" /><index-ref value="3" /><index-ref value="no" /> <points amount="25" /> </case>
+            <case> <index-ref value="1" /><index-ref value="4" /><index-ref value="no" /> <points amount="30" /> </case>
+            <case> <index-ref value="1" /><index-ref value="5" /><index-ref value="no" /> <points amount="35" /> </case>
+            <case> <index-ref value="1" /><index-ref value="6" /><index-ref value="no" /> <points amount="40" /> </case>
+            <case> <index-ref value="1" /><index-ref value="7" /><index-ref value="no" /> <points amount="45" /> </case>
+            <case> <index-ref value="1" /><index-ref value="8" /><index-ref value="no" /> <points amount="50" /> </case>
+            <case> <index-ref value="1" /><index-ref value="9" /><index-ref value="no" /> <points amount="55" /> </case>
+            <case> <index-ref value="1" /><index-ref value="10" /><index-ref value="no" /> <points amount="60" /> </case>
+            <case> <index-ref value="1" /><index-ref value="11" /><index-ref value="no" /> <points amount="65" /> </case>
+            <case> <index-ref value="1" /><index-ref value="12" /><index-ref value="no" /> <points amount="70" /> </case>
+            <case> <index-ref value="1" /><index-ref value="13" /><index-ref value="no" /> <points amount="75" /> </case>
+            <case> <index-ref value="1" /><index-ref value="14" /><index-ref value="no" /> <points amount="80" /> </case>
+            <case> <index-ref value="1" /><index-ref value="15" /><index-ref value="no" /> <points amount="85" /> </case>
+            <case> <index-ref value="1" /><index-ref value="16" /><index-ref value="no" /> <points amount="90" /> </case>
+            <case> <index-ref value="1" /><index-ref value="17" /><index-ref value="no" /> <points amount="95" /> </case>
+            <case> <index-ref value="1" /><index-ref value="18" /><index-ref value="no" /> <points amount="100" /> </case>
+            <case> <index-ref value="1" /><index-ref value="19" /><index-ref value="no" /> <points amount="105" /> </case>
+            <case> <index-ref value="1" /><index-ref value="20" /><index-ref value="no" /> <points amount="110" /> </case>
+            <case> <index-ref value="1" /><index-ref value="21" /><index-ref value="no" /> <points amount="115" /> </case>
+            <case> <index-ref value="1" /><index-ref value="22" /><index-ref value="no" /> <points amount="120" /> </case>
+            <case> <index-ref value="1" /><index-ref value="23" /><index-ref value="no" /> <points amount="125" /> </case>
+            <case> <index-ref value="1" /><index-ref value="24" /><index-ref value="no" /> <points amount="130" /> </case>
+            <case> <index-ref value="1" /><index-ref value="25" /><index-ref value="no" /> <points amount="135" /> </case>
+            <case> <index-ref value="1" /><index-ref value="26" /><index-ref value="no" /> <points amount="140" /> </case>
+            <case> <index-ref value="1" /><index-ref value="27" /><index-ref value="no" /> <points amount="145" /> </case>
+            <case> <index-ref value="1" /><index-ref value="28" /><index-ref value="no" /> <points amount="150" /> </case>
+            <case> <index-ref value="1" /><index-ref value="29" /><index-ref value="no" /> <points amount="155" /> </case>
+            <case> <index-ref value="2" /><index-ref value="0" /><index-ref value="no" /> <error message="M12-error2" /> </case>
+            <case> <index-ref value="2" /><index-ref value="1" /><index-ref value="no" /> <error message="M12-error2" /> </case>
+            <case> <index-ref value="2" /><index-ref value="2" /><index-ref value="no" /> <error message="M12-error2" /> </case>
+            <case> <index-ref value="2" /><index-ref value="3" /><index-ref value="no" /> <points amount="35" /> </case>
+            <case> <index-ref value="2" /><index-ref value="4" /><index-ref value="no" /> <points amount="40" /> </case>
+            <case> <index-ref value="2" /><index-ref value="5" /><index-ref value="no" /> <points amount="45" /> </case>
+            <case> <index-ref value="2" /><index-ref value="6" /><index-ref value="no" /> <points amount="50" /> </case>
+            <case> <index-ref value="2" /><index-ref value="7" /><index-ref value="no" /> <points amount="55" /> </case>
+            <case> <index-ref value="2" /><index-ref value="8" /><index-ref value="no" /> <points amount="60" /> </case>
+            <case> <index-ref value="2" /><index-ref value="9" /><index-ref value="no" /> <points amount="65" /> </case>
+            <case> <index-ref value="2" /><index-ref value="10" /><index-ref value="no" /> <points amount="70" /> </case>
+            <case> <index-ref value="2" /><index-ref value="11" /><index-ref value="no" /> <points amount="75" /> </case>
+            <case> <index-ref value="2" /><index-ref value="12" /><index-ref value="no" /> <points amount="80" /> </case>
+            <case> <index-ref value="2" /><index-ref value="13" /><index-ref value="no" /> <points amount="85" /> </case>
+            <case> <index-ref value="2" /><index-ref value="14" /><index-ref value="no" /> <points amount="90" /> </case>
+            <case> <index-ref value="2" /><index-ref value="15" /><index-ref value="no" /> <points amount="95" /> </case>
+            <case> <index-ref value="2" /><index-ref value="16" /><index-ref value="no" /> <points amount="100" /> </case>
+            <case> <index-ref value="2" /><index-ref value="17" /><index-ref value="no" /> <points amount="105" /> </case>
+            <case> <index-ref value="2" /><index-ref value="18" /><index-ref value="no" /> <points amount="110" /> </case>
+            <case> <index-ref value="2" /><index-ref value="19" /><index-ref value="no" /> <points amount="115" /> </case>
+            <case> <index-ref value="2" /><index-ref value="20" /><index-ref value="no" /> <points amount="120" /> </case>
+            <case> <index-ref value="2" /><index-ref value="21" /><index-ref value="no" /> <points amount="125" /> </case>
+            <case> <index-ref value="2" /><index-ref value="22" /><index-ref value="no" /> <points amount="130" /> </case>
+            <case> <index-ref value="2" /><index-ref value="23" /><index-ref value="no" /> <points amount="135" /> </case>
+            <case> <index-ref value="2" /><index-ref value="24" /><index-ref value="no" /> <points amount="140" /> </case>
+            <case> <index-ref value="2" /><index-ref value="25" /><index-ref value="no" /> <points amount="145" /> </case>
+            <case> <index-ref value="2" /><index-ref value="26" /><index-ref value="no" /> <points amount="150" /> </case>
+            <case> <index-ref value="2" /><index-ref value="27" /><index-ref value="no" /> <points amount="155" /> </case>
+            <case> <index-ref value="2" /><index-ref value="28" /><index-ref value="no" /> <points amount="160" /> </case>
+            <case> <index-ref value="2" /><index-ref value="29" /><index-ref value="no" /> <points amount="165" /> </case>
+            <case> <index-ref value="3" /><index-ref value="0" /><index-ref value="no" /> <error message="M12-error2" /> </case>
+            <case> <index-ref value="3" /><index-ref value="1" /><index-ref value="no" /> <error message="M12-error2" /> </case>
+            <case> <index-ref value="3" /><index-ref value="2" /><index-ref value="no" /> <error message="M12-error2" /> </case>
+            <case> <index-ref value="3" /><index-ref value="3" /><index-ref value="no" /> <error message="M12-error2" /> </case>
+            <case> <index-ref value="3" /><index-ref value="4" /><index-ref value="no" /> <error message="M12-error2" /> </case>
+            <case> <index-ref value="3" /><index-ref value="5" /><index-ref value="no" /> <points amount="55" /> </case>
+            <case> <index-ref value="3" /><index-ref value="6" /><index-ref value="no" /> <points amount="60" /> </case>
+            <case> <index-ref value="3" /><index-ref value="7" /><index-ref value="no" /> <points amount="65" /> </case>
+            <case> <index-ref value="3" /><index-ref value="8" /><index-ref value="no" /> <points amount="70" /> </case>
+            <case> <index-ref value="3" /><index-ref value="9" /><index-ref value="no" /> <points amount="75" /> </case>
+            <case> <index-ref value="3" /><index-ref value="10" /><index-ref value="no" /> <points amount="80" /> </case>
+            <case> <index-ref value="3" /><index-ref value="11" /><index-ref value="no" /> <points amount="85" /> </case>
+            <case> <index-ref value="3" /><index-ref value="12" /><index-ref value="no" /> <points amount="90" /> </case>
+            <case> <index-ref value="3" /><index-ref value="13" /><index-ref value="no" /> <points amount="95" /> </case>
+            <case> <index-ref value="3" /><index-ref value="14" /><index-ref value="no" /> <points amount="100" /> </case>
+            <case> <index-ref value="3" /><index-ref value="15" /><index-ref value="no" /> <points amount="105" /> </case>
+            <case> <index-ref value="3" /><index-ref value="16" /><index-ref value="no" /> <points amount="110" /> </case>
+            <case> <index-ref value="3" /><index-ref value="17" /><index-ref value="no" /> <points amount="115" /> </case>
+            <case> <index-ref value="3" /><index-ref value="18" /><index-ref value="no" /> <points amount="120" /> </case>
+            <case> <index-ref value="3" /><index-ref value="19" /><index-ref value="no" /> <points amount="125" /> </case>
+            <case> <index-ref value="3" /><index-ref value="20" /><index-ref value="no" /> <points amount="130" /> </case>
+            <case> <index-ref value="3" /><index-ref value="21" /><index-ref value="no" /> <points amount="135" /> </case>
+            <case> <index-ref value="3" /><index-ref value="22" /><index-ref value="no" /> <points amount="140" /> </case>
+            <case> <index-ref value="3" /><index-ref value="23" /><index-ref value="no" /> <points amount="145" /> </case>
+            <case> <index-ref value="3" /><index-ref value="24" /><index-ref value="no" /> <points amount="150" /> </case>
+            <case> <index-ref value="3" /><index-ref value="25" /><index-ref value="no" /> <points amount="155" /> </case>
+            <case> <index-ref value="3" /><index-ref value="26" /><index-ref value="no" /> <points amount="160" /> </case>
+            <case> <index-ref value="3" /><index-ref value="27" /><index-ref value="no" /> <points amount="165" /> </case>
+            <case> <index-ref value="3" /><index-ref value="28" /><index-ref value="no" /> <points amount="170" /> </case>
+            <case> <index-ref value="3" /><index-ref value="29" /><index-ref value="no" /> <points amount="175" /> </case>
+            <case> <index-ref value="0" /><index-ref value="0" /><index-ref value="yes" /> <points amount="0" /> </case>
+            <case> <index-ref value="0" /><index-ref value="1" /><index-ref value="yes" /> <points amount="10" /> </case>
+            <case> <index-ref value="0" /><index-ref value="2" /><index-ref value="yes" /> <points amount="15" /> </case>
+            <case> <index-ref value="0" /><index-ref value="3" /><index-ref value="yes" /> <points amount="20" /> </case>
+            <case> <index-ref value="0" /><index-ref value="4" /><index-ref value="yes" /> <points amount="25" /> </case>
+            <case> <index-ref value="0" /><index-ref value="5" /><index-ref value="yes" /> <points amount="30" /> </case>
+            <case> <index-ref value="0" /><index-ref value="6" /><index-ref value="yes" /> <points amount="35" /> </case>
+            <case> <index-ref value="0" /><index-ref value="7" /><index-ref value="yes" /> <points amount="40" /> </case>
+            <case> <index-ref value="0" /><index-ref value="8" /><index-ref value="yes" /> <points amount="45" /> </case>
+            <case> <index-ref value="0" /><index-ref value="9" /><index-ref value="yes" /> <points amount="50" /> </case>
+            <case> <index-ref value="0" /><index-ref value="10" /><index-ref value="yes" /> <points amount="55" /> </case>
+            <case> <index-ref value="0" /><index-ref value="11" /><index-ref value="yes" /> <points amount="60" /> </case>
+            <case> <index-ref value="0" /><index-ref value="12" /><index-ref value="yes" /> <points amount="65" /> </case>
+            <case> <index-ref value="0" /><index-ref value="13" /><index-ref value="yes" /> <points amount="70" /> </case>
+            <case> <index-ref value="0" /><index-ref value="14" /><index-ref value="yes" /> <points amount="75" /> </case>
+            <case> <index-ref value="0" /><index-ref value="15" /><index-ref value="yes" /> <points amount="80" /> </case>
+            <case> <index-ref value="0" /><index-ref value="16" /><index-ref value="yes" /> <points amount="85" /> </case>
+            <case> <index-ref value="0" /><index-ref value="17" /><index-ref value="yes" /> <points amount="90" /> </case>
+            <case> <index-ref value="0" /><index-ref value="18" /><index-ref value="yes" /> <points amount="95" /> </case>
+            <case> <index-ref value="0" /><index-ref value="19" /><index-ref value="yes" /> <points amount="100" /> </case>
+            <case> <index-ref value="0" /><index-ref value="20" /><index-ref value="yes" /> <points amount="105" /> </case>
+            <case> <index-ref value="0" /><index-ref value="21" /><index-ref value="yes" /> <points amount="110" /> </case>
+            <case> <index-ref value="0" /><index-ref value="22" /><index-ref value="yes" /> <points amount="115" /> </case>
+            <case> <index-ref value="0" /><index-ref value="23" /><index-ref value="yes" /> <points amount="120" /> </case>
+            <case> <index-ref value="0" /><index-ref value="24" /><index-ref value="yes" /> <points amount="125" /> </case>
+            <case> <index-ref value="0" /><index-ref value="25" /><index-ref value="yes" /> <points amount="130" /> </case>
+            <case> <index-ref value="0" /><index-ref value="26" /><index-ref value="yes" /> <points amount="135" /> </case>
+            <case> <index-ref value="0" /><index-ref value="27" /><index-ref value="yes" /> <points amount="140" /> </case>
+            <case> <index-ref value="0" /><index-ref value="28" /><index-ref value="yes" /> <points amount="145" /> </case>
+            <case> <index-ref value="0" /><index-ref value="29" /><index-ref value="yes" /> <points amount="150" /> </case>
+            <case> <index-ref value="1" /><index-ref value="0" /><index-ref value="yes" /> <error message="M12-error2" /> </case>
+            <case> <index-ref value="1" /><index-ref value="1" /><index-ref value="yes" /> <points amount="20" /> </case>
+            <case> <index-ref value="1" /><index-ref value="2" /><index-ref value="yes" /> <points amount="25" /> </case>
+            <case> <index-ref value="1" /><index-ref value="3" /><index-ref value="yes" /> <points amount="30" /> </case>
+            <case> <index-ref value="1" /><index-ref value="4" /><index-ref value="yes" /> <points amount="35" /> </case>
+            <case> <index-ref value="1" /><index-ref value="5" /><index-ref value="yes" /> <points amount="40" /> </case>
+            <case> <index-ref value="1" /><index-ref value="6" /><index-ref value="yes" /> <points amount="45" /> </case>
+            <case> <index-ref value="1" /><index-ref value="7" /><index-ref value="yes" /> <points amount="50" /> </case>
+            <case> <index-ref value="1" /><index-ref value="8" /><index-ref value="yes" /> <points amount="55" /> </case>
+            <case> <index-ref value="1" /><index-ref value="9" /><index-ref value="yes" /> <points amount="60" /> </case>
+            <case> <index-ref value="1" /><index-ref value="10" /><index-ref value="yes" /> <points amount="65" /> </case>
+            <case> <index-ref value="1" /><index-ref value="11" /><index-ref value="yes" /> <points amount="70" /> </case>
+            <case> <index-ref value="1" /><index-ref value="12" /><index-ref value="yes" /> <points amount="75" /> </case>
+            <case> <index-ref value="1" /><index-ref value="13" /><index-ref value="yes" /> <points amount="80" /> </case>
+            <case> <index-ref value="1" /><index-ref value="14" /><index-ref value="yes" /> <points amount="85" /> </case>
+            <case> <index-ref value="1" /><index-ref value="15" /><index-ref value="yes" /> <points amount="90" /> </case>
+            <case> <index-ref value="1" /><index-ref value="16" /><index-ref value="yes" /> <points amount="95" /> </case>
+            <case> <index-ref value="1" /><index-ref value="17" /><index-ref value="yes" /> <points amount="100" /> </case>
+            <case> <index-ref value="1" /><index-ref value="18" /><index-ref value="yes" /> <points amount="105" /> </case>
+            <case> <index-ref value="1" /><index-ref value="19" /><index-ref value="yes" /> <points amount="110" /> </case>
+            <case> <index-ref value="1" /><index-ref value="20" /><index-ref value="yes" /> <points amount="115" /> </case>
+            <case> <index-ref value="1" /><index-ref value="21" /><index-ref value="yes" /> <points amount="120" /> </case>
+            <case> <index-ref value="1" /><index-ref value="22" /><index-ref value="yes" /> <points amount="125" /> </case>
+            <case> <index-ref value="1" /><index-ref value="23" /><index-ref value="yes" /> <points amount="130" /> </case>
+            <case> <index-ref value="1" /><index-ref value="24" /><index-ref value="yes" /> <points amount="135" /> </case>
+            <case> <index-ref value="1" /><index-ref value="25" /><index-ref value="yes" /> <points amount="140" /> </case>
+            <case> <index-ref value="1" /><index-ref value="26" /><index-ref value="yes" /> <points amount="145" /> </case>
+            <case> <index-ref value="1" /><index-ref value="27" /><index-ref value="yes" /> <points amount="150" /> </case>
+            <case> <index-ref value="1" /><index-ref value="28" /><index-ref value="yes" /> <points amount="155" /> </case>
+            <case> <index-ref value="1" /><index-ref value="29" /><index-ref value="yes" /> <points amount="160" /> </case>
+            <case> <index-ref value="2" /><index-ref value="0" /><index-ref value="yes" /> <error message="M12-error2" /> </case>
+            <case> <index-ref value="2" /><index-ref value="1" /><index-ref value="yes" /> <error message="M12-error2" /> </case>
+            <case> <index-ref value="2" /><index-ref value="2" /><index-ref value="yes" /> <error message="M12-error2" /> </case>
+            <case> <index-ref value="2" /><index-ref value="3" /><index-ref value="yes" /> <points amount="40" /> </case>
+            <case> <index-ref value="2" /><index-ref value="4" /><index-ref value="yes" /> <points amount="45" /> </case>
+            <case> <index-ref value="2" /><index-ref value="5" /><index-ref value="yes" /> <points amount="50" /> </case>
+            <case> <index-ref value="2" /><index-ref value="6" /><index-ref value="yes" /> <points amount="55" /> </case>
+            <case> <index-ref value="2" /><index-ref value="7" /><index-ref value="yes" /> <points amount="60" /> </case>
+            <case> <index-ref value="2" /><index-ref value="8" /><index-ref value="yes" /> <points amount="65" /> </case>
+            <case> <index-ref value="2" /><index-ref value="9" /><index-ref value="yes" /> <points amount="70" /> </case>
+            <case> <index-ref value="2" /><index-ref value="10" /><index-ref value="yes" /> <points amount="75" /> </case>
+            <case> <index-ref value="2" /><index-ref value="11" /><index-ref value="yes" /> <points amount="80" /> </case>
+            <case> <index-ref value="2" /><index-ref value="12" /><index-ref value="yes" /> <points amount="85" /> </case>
+            <case> <index-ref value="2" /><index-ref value="13" /><index-ref value="yes" /> <points amount="90" /> </case>
+            <case> <index-ref value="2" /><index-ref value="14" /><index-ref value="yes" /> <points amount="95" /> </case>
+            <case> <index-ref value="2" /><index-ref value="15" /><index-ref value="yes" /> <points amount="100" /> </case>
+            <case> <index-ref value="2" /><index-ref value="16" /><index-ref value="yes" /> <points amount="105" /> </case>
+            <case> <index-ref value="2" /><index-ref value="17" /><index-ref value="yes" /> <points amount="110" /> </case>
+            <case> <index-ref value="2" /><index-ref value="18" /><index-ref value="yes" /> <points amount="115" /> </case>
+            <case> <index-ref value="2" /><index-ref value="19" /><index-ref value="yes" /> <points amount="120" /> </case>
+            <case> <index-ref value="2" /><index-ref value="20" /><index-ref value="yes" /> <points amount="125" /> </case>
+            <case> <index-ref value="2" /><index-ref value="21" /><index-ref value="yes" /> <points amount="130" /> </case>
+            <case> <index-ref value="2" /><index-ref value="22" /><index-ref value="yes" /> <points amount="135" /> </case>
+            <case> <index-ref value="2" /><index-ref value="23" /><index-ref value="yes" /> <points amount="140" /> </case>
+            <case> <index-ref value="2" /><index-ref value="24" /><index-ref value="yes" /> <points amount="145" /> </case>
+            <case> <index-ref value="2" /><index-ref value="25" /><index-ref value="yes" /> <points amount="150" /> </case>
+            <case> <index-ref value="2" /><index-ref value="26" /><index-ref value="yes" /> <points amount="155" /> </case>
+            <case> <index-ref value="2" /><index-ref value="27" /><index-ref value="yes" /> <points amount="160" /> </case>
+            <case> <index-ref value="2" /><index-ref value="28" /><index-ref value="yes" /> <points amount="165" /> </case>
+            <case> <index-ref value="2" /><index-ref value="29" /><index-ref value="yes" /> <points amount="170" /> </case>
+            <case> <index-ref value="3" /><index-ref value="0" /><index-ref value="yes" /> <error message="M12-error2" /> </case>
+            <case> <index-ref value="3" /><index-ref value="1" /><index-ref value="yes" /> <error message="M12-error2" /> </case>
+            <case> <index-ref value="3" /><index-ref value="2" /><index-ref value="yes" /> <error message="M12-error2" /> </case>
+            <case> <index-ref value="3" /><index-ref value="3" /><index-ref value="yes" /> <error message="M12-error2" /> </case>
+            <case> <index-ref value="3" /><index-ref value="4" /><index-ref value="yes" /> <error message="M12-error2" /> </case>
+            <case> <index-ref value="3" /><index-ref value="5" /><index-ref value="yes" /> <points amount="60" /> </case>
+            <case> <index-ref value="3" /><index-ref value="6" /><index-ref value="yes" /> <points amount="65" /> </case>
+            <case> <index-ref value="3" /><index-ref value="7" /><index-ref value="yes" /> <points amount="70" /> </case>
+            <case> <index-ref value="3" /><index-ref value="8" /><index-ref value="yes" /> <points amount="75" /> </case>
+            <case> <index-ref value="3" /><index-ref value="9" /><index-ref value="yes" /> <points amount="80" /> </case>
+            <case> <index-ref value="3" /><index-ref value="10" /><index-ref value="yes" /> <points amount="85" /> </case>
+            <case> <index-ref value="3" /><index-ref value="11" /><index-ref value="yes" /> <points amount="90" /> </case>
+            <case> <index-ref value="3" /><index-ref value="12" /><index-ref value="yes" /> <points amount="95" /> </case>
+            <case> <index-ref value="3" /><index-ref value="13" /><index-ref value="yes" /> <points amount="100" /> </case>
+            <case> <index-ref value="3" /><index-ref value="14" /><index-ref value="yes" /> <points amount="105" /> </case>
+            <case> <index-ref value="3" /><index-ref value="15" /><index-ref value="yes" /> <points amount="110" /> </case>
+            <case> <index-ref value="3" /><index-ref value="16" /><index-ref value="yes" /> <points amount="115" /> </case>
+            <case> <index-ref value="3" /><index-ref value="17" /><index-ref value="yes" /> <points amount="120" /> </case>
+            <case> <index-ref value="3" /><index-ref value="18" /><index-ref value="yes" /> <points amount="125" /> </case>
+            <case> <index-ref value="3" /><index-ref value="19" /><index-ref value="yes" /> <points amount="130" /> </case>
+            <case> <index-ref value="3" /><index-ref value="20" /><index-ref value="yes" /> <points amount="135" /> </case>
+            <case> <index-ref value="3" /><index-ref value="21" /><index-ref value="yes" /> <points amount="140" /> </case>
+            <case> <index-ref value="3" /><index-ref value="22" /><index-ref value="yes" /> <points amount="145" /> </case>
+            <case> <index-ref value="3" /><index-ref value="23" /><index-ref value="yes" /> <points amount="150" /> </case>
+            <case> <index-ref value="3" /><index-ref value="24" /><index-ref value="yes" /> <points amount="155" /> </case>
+            <case> <index-ref value="3" /><index-ref value="25" /><index-ref value="yes" /> <points amount="160" /> </case>
+            <case> <index-ref value="3" /><index-ref value="26" /><index-ref value="yes" /> <points amount="165" /> </case>
+            <case> <index-ref value="3" /><index-ref value="27" /><index-ref value="yes" /> <points amount="170" /> </case>
+            <case> <index-ref value="3" /><index-ref value="28" /><index-ref value="yes" /> <points amount="175" /> </case>
+            <case> <index-ref value="3" /><index-ref value="29" /><index-ref value="yes" /> <points amount="180" /> </case>
+          </cases>
         </score>
     </mission>
 


### PR DESCRIPTION
Based on discussions with Alan

1) allow for 17 Building Units:  (4 red + 4 white + 4 tan) + (4 blue) + (1 hooked blue)
  ==> 29 levels possible in M12, 2 *(4 red + 4 white + 4 tan) + 1*(4 blue + 1 hooked blue)

2) M02 Crane only has four valid answers to scoresheet questions:  NNN, YNN, YYN, YYY

3) Includes Building Units as RESOURCE to trigger error condition
==> used in M02, M05, M12
==> M12 uses approximate count, i.e. (height)/2.  Better would be (height+1)/2 [except for height > 24]
****** this means that scoring program does not show score for M02, M05, M12 until all three have answers ******

4) Note that M05 is only allowing for up to 10 units for each question.  Could add more scoring cases, if we see a need.
