### PR TITLE
Initialize resource objectives to null

### DIFF
--- a/tools/buildchallenge.js
+++ b/tools/buildchallenge.js
@@ -105,7 +105,7 @@ function parseObjective(xml) {
     if (obj.title.length===1) {obj.title = obj.title[0];}
     obj.type = xml.$.type;
     obj.default = xml.$.default;
-    if (obj.type === 'number') obj.default = Number(xml.$.default):
+    if (obj.type === 'number') obj.default = Number(xml.$.default);
     if (xml.$.min!==undefined) {obj.min = Number(xml.$.min);}
     if (xml.$.max!==undefined) {obj.max = Number(xml.$.max);}
     return obj;

--- a/tools/buildchallenge.js
+++ b/tools/buildchallenge.js
@@ -108,6 +108,7 @@ function parseObjective(xml) {
     if (obj.type === 'number') obj.default = Number(xml.$.default);
     if (xml.$.min!==undefined) {obj.min = Number(xml.$.min);}
     if (xml.$.max!==undefined) {obj.max = Number(xml.$.max);}
+    if (xml.$.resource) obj.value = null;
     return obj;
 }
 


### PR DESCRIPTION
Set objective.value = null when an objective is linked to a resource.
This allows the scoring module to show a mission as complete when it has an objective linked to a resource, and objectives from other missions linked to that resource are not set yet.