### PR TITLE
Allow wildcard values

### DIFF
--- a/tools/buildchallenge.js
+++ b/tools/buildchallenge.js
@@ -79,6 +79,7 @@ function parseScore(xml, resources) {
     var lines = resources.map(r => r.code)
       .concat(xml.cases[0].case.map(parseCondition).map(function(line) {
         var conditions = line.values.map(function(value,index) {
+            if( value === "*any*" ) return 'true';
             return deps[index] + ' === \'' + value + '\'';
         }).join(' && ');
 


### PR DESCRIPTION
In a scoring case, treat the special value of "\*any\*" as a wildcard.
The case is valid for any value of the index-ref